### PR TITLE
Per-app background access toggles for clipboard and audio recording

### DIFF
--- a/core/java/android/app/AppOpsManager.java
+++ b/core/java/android/app/AppOpsManager.java
@@ -254,8 +254,10 @@ public class AppOpsManager {
     public static final int OP_ANSWER_PHONE_CALLS = 69;
     /** @hide */
     public static final int OP_READ_CLIPBOARD_BACKGROUND = 70;
+    /** @hide Record Audio in the background */
+    public static final int OP_RECORD_AUDIO_BACKGROUND = 71;
     /** @hide */
-    public static final int _NUM_OP = 71;
+    public static final int _NUM_OP = 72;
 
     /** Access to coarse location information. */
     public static final String OPSTR_COARSE_LOCATION = "android:coarse_location";
@@ -495,7 +497,8 @@ public class AppOpsManager {
             OP_PICTURE_IN_PICTURE,
             OP_INSTANT_APP_START_FOREGROUND,
             OP_ANSWER_PHONE_CALLS,
-            OP_READ_CLIPBOARD_BACKGROUND
+            OP_READ_CLIPBOARD_BACKGROUND,
+            OP_RECORD_AUDIO_BACKGROUND
     };
 
     /**
@@ -573,6 +576,7 @@ public class AppOpsManager {
             OPSTR_PICTURE_IN_PICTURE,
             OPSTR_INSTANT_APP_START_FOREGROUND,
             OPSTR_ANSWER_PHONE_CALLS,
+            null,
             null
     };
 
@@ -651,7 +655,8 @@ public class AppOpsManager {
             "PICTURE_IN_PICTURE",
             "INSTANT_APP_START_FOREGROUND",
             "ANSWER_PHONE_CALLS",
-            "READ_CLIPBOARD_BACKGROUND"
+            "READ_CLIPBOARD_BACKGROUND",
+            "RECORD_AUDIO_BACKGROUND"
     };
 
     /**
@@ -729,7 +734,8 @@ public class AppOpsManager {
             null, // no permission for entering picture-in-picture on hide
             Manifest.permission.INSTANT_APP_FOREGROUND_SERVICE,
             Manifest.permission.ANSWER_PHONE_CALLS,
-            null // no permission for reading clipboard in the background
+            null, // no permission for reading clipboard in the background
+            android.Manifest.permission.RECORD_AUDIO
     };
 
     /**
@@ -808,7 +814,8 @@ public class AppOpsManager {
             null, // ENTER_PICTURE_IN_PICTURE_ON_HIDE
             null, // INSTANT_APP_START_FOREGROUND
             null, // ANSWER_PHONE_CALLS
-            null //READ_CLIPBOARD_BACKGROUND
+            null, //READ_CLIPBOARD_BACKGROUND
+            UserManager.DISALLOW_RECORD_AUDIO // RECORD_AUDIO_BACKGROUND
     };
 
     /**
@@ -886,7 +893,8 @@ public class AppOpsManager {
             false, // ENTER_PICTURE_IN_PICTURE_ON_HIDE
             false, // INSTANT_APP_START_FOREGROUND
             false, // ANSWER_PHONE_CALLS
-            false // READ_CLIPBOARD_BACKGROUND
+            false, // READ_CLIPBOARD_BACKGROUND
+            false // RECORD_AUDIO_BACKGROUND
     };
 
     /**
@@ -963,7 +971,8 @@ public class AppOpsManager {
             AppOpsManager.MODE_ALLOWED,  // OP_PICTURE_IN_PICTURE
             AppOpsManager.MODE_DEFAULT,  // OP_INSTANT_APP_START_FOREGROUND
             AppOpsManager.MODE_ALLOWED, // ANSWER_PHONE_CALLS
-            AppOpsManager.MODE_IGNORED // OP_READ_CLIPBOARD_BACKGROUND
+            AppOpsManager.MODE_IGNORED, // OP_READ_CLIPBOARD_BACKGROUND
+            AppOpsManager.MODE_IGNORED // OP_RECORD_AUDIO_BACKGROUND
     };
 
     /**
@@ -1044,6 +1053,7 @@ public class AppOpsManager {
             false, // OP_PICTURE_IN_PICTURE
             false,
             false, // ANSWER_PHONE_CALLS
+            false,
             false
     };
 
@@ -1108,6 +1118,7 @@ public class AppOpsManager {
 
         // All the Ops having a matching background op
         sOpToBgOp.put(OP_READ_CLIPBOARD, OP_READ_CLIPBOARD_BACKGROUND);
+        sOpToBgOp.put(OP_RECORD_AUDIO, OP_RECORD_AUDIO_BACKGROUND);
     }
 
     /**

--- a/core/java/android/app/AppOpsManager.java
+++ b/core/java/android/app/AppOpsManager.java
@@ -1047,6 +1047,11 @@ public class AppOpsManager {
      */
     private static HashMap<String, Integer> sPermToOp = new HashMap<>();
 
+    /**
+     * Mapping from an app op code to the coressponding background app op code.
+     */
+    private static HashMap<Integer, Integer> sOpToBgOp = new HashMap<>();
+
     static {
         if (sOpToSwitch.length != _NUM_OP) {
             throw new IllegalStateException("sOpToSwitch length " + sOpToSwitch.length
@@ -1171,6 +1176,22 @@ public class AppOpsManager {
      */
     public static boolean opAllowsReset(int op) {
         return !sOpDisableReset[op];
+    }
+
+    /**
+     * Retrieve the background op of an op
+     * @hide
+     */
+    public static int opToBgOp(int op) {
+        return sOpToBgOp.get(op);
+    }
+
+    /**
+     * Check whether op has a matching bg op
+     * @hide
+     */
+    public static boolean isBgOp(int op) {
+        return sOpToBgOp.containsKey(op);
     }
 
     /**

--- a/core/java/android/app/AppOpsManager.java
+++ b/core/java/android/app/AppOpsManager.java
@@ -253,7 +253,9 @@ public class AppOpsManager {
     /** @hide Answer incoming phone calls */
     public static final int OP_ANSWER_PHONE_CALLS = 69;
     /** @hide */
-    public static final int _NUM_OP = 70;
+    public static final int OP_READ_CLIPBOARD_BACKGROUND = 70;
+    /** @hide */
+    public static final int _NUM_OP = 71;
 
     /** Access to coarse location information. */
     public static final String OPSTR_COARSE_LOCATION = "android:coarse_location";
@@ -492,7 +494,8 @@ public class AppOpsManager {
             OP_REQUEST_INSTALL_PACKAGES,
             OP_PICTURE_IN_PICTURE,
             OP_INSTANT_APP_START_FOREGROUND,
-            OP_ANSWER_PHONE_CALLS
+            OP_ANSWER_PHONE_CALLS,
+            OP_READ_CLIPBOARD_BACKGROUND
     };
 
     /**
@@ -570,6 +573,7 @@ public class AppOpsManager {
             OPSTR_PICTURE_IN_PICTURE,
             OPSTR_INSTANT_APP_START_FOREGROUND,
             OPSTR_ANSWER_PHONE_CALLS,
+            null
     };
 
     /**
@@ -647,6 +651,7 @@ public class AppOpsManager {
             "PICTURE_IN_PICTURE",
             "INSTANT_APP_START_FOREGROUND",
             "ANSWER_PHONE_CALLS",
+            "READ_CLIPBOARD_BACKGROUND"
     };
 
     /**
@@ -724,6 +729,7 @@ public class AppOpsManager {
             null, // no permission for entering picture-in-picture on hide
             Manifest.permission.INSTANT_APP_FOREGROUND_SERVICE,
             Manifest.permission.ANSWER_PHONE_CALLS,
+            null // no permission for reading clipboard in the background
     };
 
     /**
@@ -802,6 +808,7 @@ public class AppOpsManager {
             null, // ENTER_PICTURE_IN_PICTURE_ON_HIDE
             null, // INSTANT_APP_START_FOREGROUND
             null, // ANSWER_PHONE_CALLS
+            null //READ_CLIPBOARD_BACKGROUND
     };
 
     /**
@@ -879,6 +886,7 @@ public class AppOpsManager {
             false, // ENTER_PICTURE_IN_PICTURE_ON_HIDE
             false, // INSTANT_APP_START_FOREGROUND
             false, // ANSWER_PHONE_CALLS
+            false // READ_CLIPBOARD_BACKGROUND
     };
 
     /**
@@ -955,6 +963,7 @@ public class AppOpsManager {
             AppOpsManager.MODE_ALLOWED,  // OP_PICTURE_IN_PICTURE
             AppOpsManager.MODE_DEFAULT,  // OP_INSTANT_APP_START_FOREGROUND
             AppOpsManager.MODE_ALLOWED, // ANSWER_PHONE_CALLS
+            AppOpsManager.MODE_IGNORED // OP_READ_CLIPBOARD_BACKGROUND
     };
 
     /**
@@ -1035,6 +1044,7 @@ public class AppOpsManager {
             false, // OP_PICTURE_IN_PICTURE
             false,
             false, // ANSWER_PHONE_CALLS
+            false
     };
 
     /**
@@ -1095,6 +1105,9 @@ public class AppOpsManager {
                 sPermToOp.put(sOpPerms[op], op);
             }
         }
+
+        // All the Ops having a matching background op
+        sOpToBgOp.put(OP_READ_CLIPBOARD, OP_READ_CLIPBOARD_BACKGROUND);
     }
 
     /**

--- a/services/core/java/com/android/server/AppOpsService.java
+++ b/services/core/java/com/android/server/AppOpsService.java
@@ -1120,6 +1120,34 @@ public class AppOpsService extends IAppOpsService.Stub {
                     return switchOp.mode;
                 }
             }
+
+            if (AppOpsManager.isBgOp(code) || AppOpsManager.isBgOp(switchCode)) {
+                try {
+                    boolean fg = ActivityManager.getService().isAppForeground(uid);
+                    if (!fg) {
+                        Op bgOp = getOpLocked(ops, AppOpsManager.opToBgOp(code), true);
+                        if (bgOp.mode != AppOpsManager.MODE_ALLOWED) {
+                            if (DEBUG) Log.d(TAG, "noteOperation: reject #" + op.mode + " for code "
+                                    + switchCode + " (" + code + ") uid " + uid + " package "
+                                    + packageName + " as it is not a foreground app");
+                            op.rejectTime = System.currentTimeMillis();
+                            return AppOpsManager.MODE_IGNORED;
+                        }
+
+                        Op bgSwitchOp = getOpLocked(ops, AppOpsManager.opToBgOp(switchCode), true);
+                        if (bgSwitchOp.mode != AppOpsManager.MODE_ALLOWED) {
+                            if (DEBUG) Log.d(TAG, "noteOperation: reject #" + op.mode + " for code "
+                                    + switchCode + " (" + code + ") uid " + uid + " package "
+                                    + packageName + " as it is not a foreground app");
+                            op.rejectTime = System.currentTimeMillis();
+                            return AppOpsManager.MODE_IGNORED;
+                        }
+                    }
+                } catch (RemoteException e) {
+                    Log.d(TAG, "noteOperation: failed to get ActivityManager service");
+                }
+            }
+
             if (DEBUG) Log.d(TAG, "noteOperation: allowing code " + code + " uid " + uid
                     + " package " + packageName);
             op.time = System.currentTimeMillis();
@@ -1170,6 +1198,34 @@ public class AppOpsService extends IAppOpsService.Stub {
                 op.rejectTime = System.currentTimeMillis();
                 return switchOp.mode;
             }
+
+            if (AppOpsManager.isBgOp(code) || AppOpsManager.isBgOp(switchCode)) {
+                try {
+                    boolean fg = ActivityManager.getService().isAppForeground(uid);
+                    if (!fg) {
+                        Op bgOp = getOpLocked(ops, AppOpsManager.opToBgOp(code), true);
+                        if (bgOp.mode != AppOpsManager.MODE_ALLOWED) {
+                            if (DEBUG) Log.d(TAG, "startOperation: reject #" + op.mode + " for code "
+                                    + switchCode + " (" + code + ") uid " + uid + " package "
+                                    + packageName + " as it is not a foreground app");
+                            op.rejectTime = System.currentTimeMillis();
+                            return AppOpsManager.MODE_IGNORED;
+                        }
+
+                        Op bgSwitchOp = getOpLocked(ops, AppOpsManager.opToBgOp(switchCode), true);
+                        if (bgSwitchOp.mode != AppOpsManager.MODE_ALLOWED) {
+                            if (DEBUG) Log.d(TAG, "startOperation: reject #" + op.mode + " for code "
+                                    + switchCode + " (" + code + ") uid " + uid + " package "
+                                    + packageName + " as it is not a foreground app");
+                            op.rejectTime = System.currentTimeMillis();
+                            return AppOpsManager.MODE_IGNORED;
+                        }
+                    }
+                } catch (RemoteException e) {
+                    Log.d(TAG, "startOperation: failed to get ActivityManager service");
+                }
+            }
+
             if (DEBUG) Log.d(TAG, "startOperation: allowing code " + code + " uid " + uid
                     + " package " + resolvedPackageName);
             if (op.nesting == 0) {

--- a/services/core/java/com/android/server/audio/AudioService.java
+++ b/services/core/java/com/android/server/audio/AudioService.java
@@ -186,6 +186,7 @@ public class AudioService extends IAudioService.Stub
     private final Context mContext;
     private final ContentResolver mContentResolver;
     private final AppOpsManager mAppOps;
+    private final ActivityManager mActivityManager;
 
     // the platform type affects volume and silent mode behavior
     private final int mPlatformType;
@@ -667,6 +668,8 @@ public class AudioService extends IAudioService.Stub
         mContext = context;
         mContentResolver = context.getContentResolver();
         mAppOps = (AppOpsManager)context.getSystemService(Context.APP_OPS_SERVICE);
+        mActivityManager
+                = (ActivityManager) mContext.getSystemService(Context.ACTIVITY_SERVICE);
 
         mPlatformType = AudioSystem.getPlatformType(context);
 
@@ -803,6 +806,51 @@ public class AudioService extends IAudioService.Stub
         mRecordMonitor.initMonitor();
     }
 
+    public void systemRunning() {
+        // listen for background/foreground changes
+        ActivityManager.OnUidImportanceListener uidImportanceListener
+        = new ActivityManager.OnUidImportanceListener() {
+            @Override
+            public void onUidImportance(int uid, int importance) {
+                boolean foreground = isImportanceForeground(importance);
+                // Skip foreground processes
+                if (foreground) {
+                    return;
+                }
+                // Skip system processes
+                if (UserHandle.getAppId(uid) < FIRST_APPLICATION_UID) {
+                    return;
+                }
+                final String[] packages = mContext.getPackageManager().getPackagesForUid(uid);
+                for (String packageName : packages) {
+                    try {
+                        PackageInfo pi = mContext.getPackageManager().getPackageInfo(packageName, PackageManager.GET_PERMISSIONS);
+                        if (Arrays.asList(pi.requestedPermissions).contains(android.Manifest.permission.RECORD_AUDIO)) {
+                            int mode = mAppOps.checkOp(AppOpsManager.OP_RECORD_AUDIO_BACKGROUND, uid, packageName);
+                            if (mode != AppOpsManager.MODE_ALLOWED) {
+                                try {
+                                    ActivityManager.getService().killUid(UserHandle.getAppId(uid),
+                                        UserHandle.getUserId(uid),
+                                        "killBackgroundProcessWithoutAudioRecordBackgroundPermission");
+                                } catch (RemoteException e) {
+                                    Log.w(TAG, "Error calling killUid", e);
+                                }
+                            }
+                        }
+                    } catch (PackageManager.NameNotFoundException e) {
+                        // Do nothing.
+                    }
+                }
+            }
+        };
+        mActivityManager.addOnUidImportanceListener(uidImportanceListener,
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE);
+    }
+
+    private static boolean isImportanceForeground(int importance) {
+        return importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE;
+    }
+
     public void systemReady() {
         sendMsg(mAudioHandler, MSG_SYSTEM_READY, SENDMSG_QUEUE,
                 0, 0, null, 0);
@@ -872,6 +920,7 @@ public class AudioService extends IAudioService.Stub
 
         initA11yMonitoring();
         onIndicateSystemReady();
+        systemRunning();
     }
 
     void onIndicateSystemReady() {

--- a/services/core/java/com/android/server/clipboard/ClipboardService.java
+++ b/services/core/java/com/android/server/clipboard/ClipboardService.java
@@ -574,16 +574,10 @@ public class ClipboardService extends SystemService {
             // Installed apps can access the clipboard at any time.
             if (!AppGlobals.getPackageManager().isInstantApp(callingPackage,
                         UserHandle.getUserId(callingUid))) {
-                if (SystemProperties.getBoolean("persist.security.bg_clipboard", false)) {
-                    return true;
-                }
+                return true;
             }
             // Instant apps can only access the clipboard if they are in the foreground.
-            boolean foreground = mAm.isAppForeground(callingUid);
-            if (!foreground) {
-                Slog.w(TAG, "denied background clipboard access for " + callingPackage);
-            }
-            return foreground;
+            return mAm.isAppForeground(callingUid);
         } catch (RemoteException e) {
             Slog.e("clipboard", "Failed to get Instant App status for package " + callingPackage,
                     e);


### PR DESCRIPTION
This introduces a generic way to disallow an Op while the requesting app is in the background, with a special Op suffixed _BACKGROUND.

First user is clipboard, which doesn't take much apart from just adding it to the list.

For microphone access, we additionally also kill apps which start recording in the foreground and then go to the background, but don't have the background record permission.

Settings part: https://github.com/CopperheadOS/platform_packages_apps_Settings/pull/2