### PR TITLE
AppOps: Allow background audio record by default

### DIFF
--- a/core/java/android/app/AppOpsManager.java
+++ b/core/java/android/app/AppOpsManager.java
@@ -972,7 +972,7 @@ public class AppOpsManager {
             AppOpsManager.MODE_DEFAULT,  // OP_INSTANT_APP_START_FOREGROUND
             AppOpsManager.MODE_ALLOWED, // ANSWER_PHONE_CALLS
             AppOpsManager.MODE_IGNORED, // OP_READ_CLIPBOARD_BACKGROUND
-            AppOpsManager.MODE_IGNORED // OP_RECORD_AUDIO_BACKGROUND
+            AppOpsManager.MODE_ALLOWED // OP_RECORD_AUDIO_BACKGROUND
     };
 
     /**


### PR DESCRIPTION
* The previous behavior disabled background audio record for *ALL*
  apps which used the RECORD_AUDIO, including apps such as
  Phone Services (used for voice calls) and Noise.
  That broke them more than expected, so just allow this by default for now.

TODO: Add a whitelist, so system apps can be filtered out.