### PR TITLE
Fix for non-working tiles

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/BluetoothTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/BluetoothTile.java
@@ -123,16 +123,16 @@ public class BluetoothTile extends QSTileImpl<BooleanState> {
 
     @Override
     protected void handleSecondaryClick() {
-        if (!mController.canConfigBluetooth()) {
-            mActivityStarter.postStartActivityDismissingKeyguard(
-                    new Intent(Settings.ACTION_BLUETOOTH_SETTINGS), 0);
-            return;
-        }
         if (mKeyguard.isSecure() && mKeyguard.isShowing()) {
             Dependency.get(ActivityStarter.class).postQSRunnableDismissingKeyguard(() -> {
                 mHost.openPanels();
                 showDetail(true);
             });
+            return;
+        }
+        if (!mController.canConfigBluetooth()) {
+            mActivityStarter.postStartActivityDismissingKeyguard(
+                    new Intent(Settings.ACTION_BLUETOOTH_SETTINGS), 0);
             return;
         }
         showDetail(true);

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/CellularTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/CellularTile.java
@@ -62,7 +62,6 @@ public class CellularTile extends QSTileImpl<SignalState> {
 
     private final CellSignalCallback mSignalCallback = new CellSignalCallback();
     private final ActivityStarter mActivityStarter;
-    private final KeyguardMonitor mKeyguardMonitor;
 
     private final KeyguardMonitor mKeyguard;
     private final KeyguardCallback mKeyguardCallback = new KeyguardCallback();
@@ -73,7 +72,6 @@ public class CellularTile extends QSTileImpl<SignalState> {
         super(host);
         mController = networkController;
         mActivityStarter = activityStarter;
-        mKeyguardMonitor = Dependency.get(KeyguardMonitor.class);
         mKeyguard = Dependency.get(KeyguardMonitor.class);
         mDataController = mController.getMobileDataController();
         mDetailAdapter = new CellularDetailAdapter();
@@ -110,16 +108,16 @@ public class CellularTile extends QSTileImpl<SignalState> {
         if (getState().state == Tile.STATE_UNAVAILABLE) {
             return;
         }
+        if (mKeyguard.isSecure() && mKeyguard.isShowing()) {
+            Dependency.get(ActivityStarter.class).postQSRunnableDismissingKeyguard(() -> {
+                mHost.openPanels();
+                mDataController.setMobileDataEnabled(true);
+            });
+            return;
+        }
         if (mDataController.isMobileDataEnabled()) {
             maybeShowDisableDialog();
         } else {
-            if (mKeyguard.isSecure() && mKeyguard.isShowing()) {
-                Dependency.get(ActivityStarter.class).postQSRunnableDismissingKeyguard(() -> {
-                    mHost.openPanels();
-                    mDataController.setMobileDataEnabled(true);
-                });
-                return;
-            }
             mDataController.setMobileDataEnabled(true);
         }
     }


### PR DESCRIPTION
Bluetooth and cellular tiles weren't working with the most earlier changes I sent.

With these changes, all tiles have been tested and require unlocking before they can be activated.