### PR TITLE
Restore special runtime permissions, make INTERNET into a special runtime permission, and add INTERNET to NETWORK permission group

### DIFF
--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -1513,7 +1513,7 @@
     <permission android:name="android.permission.INTERNET"
         android:description="@string/permdesc_createNetworkSockets"
         android:label="@string/permlab_createNetworkSockets"
-        android:protectionLevel="normal|instant" />
+        android:protectionLevel="dangerous|instant" />
 
     <!-- Allows applications to access information about networks.
          <p>Protection level: normal

--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -1507,10 +1507,20 @@
     <!-- ======================================= -->
     <eat-comment />
 
+    <!-- Network access
+         @hide
+    -->
+    <permission-group android:name="android.permission-group.NETWORK"
+        android:icon="@drawable/perm_group_network"
+        android:label="@string/permgrouplab_network"
+        android:description="@string/permgroupdesc_network"
+        android:priority="900" />
+
     <!-- Allows applications to open network sockets.
          <p>Protection level: normal
     -->
     <permission android:name="android.permission.INTERNET"
+        android:permissionGroup="android.permission-group.NETWORK"
         android:description="@string/permdesc_createNetworkSockets"
         android:label="@string/permlab_createNetworkSockets"
         android:protectionLevel="dangerous|instant" />

--- a/core/res/res/values/strings.xml
+++ b/core/res/res/values/strings.xml
@@ -789,6 +789,11 @@
     <string name="permgrouprequest_sensors">Allow
         &lt;b><xliff:g id="app_name" example="Gmail">%1$s</xliff:g>&lt;/b> to access sensor data about your vital signs?</string>
 
+    <!-- Title of a category of application permissions, listed so the user can choose whether they want to allow the application to do this. -->
+    <string name="permgrouplab_network">Network</string>
+    <!-- Description of a category of application permissions, listed so the user can choose whether they want to allow the application to do this. -->
+    <string name="permgroupdesc_network">network access</string>
+
     <!-- Title for the capability of an accessibility service to retrieve window content. -->
     <string name="capability_title_canRetrieveWindowContent">Retrieve window content</string>
     <!-- Description for the capability of an accessibility service to retrieve window content. -->

--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -19926,7 +19926,8 @@ public class PackageManagerService extends IPackageManager.Stub
             }
 
             // If this permission was granted by default, make sure it is.
-            if ((oldFlags & FLAG_PERMISSION_GRANTED_BY_DEFAULT) != 0) {
+            if ((oldFlags & FLAG_PERMISSION_GRANTED_BY_DEFAULT) != 0
+                    || PermissionManagerService.isSpecialRuntimePermission(bp.getName())) {
                 mPermissionManager.grantRuntimePermission(permName, packageName, false,
                         Process.SYSTEM_UID, userId, delayingPermCallback);
             // If permission review is enabled the permissions for a legacy apps

--- a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
+++ b/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
@@ -856,7 +856,7 @@ public class PermissionManagerService {
     }
 
     public static boolean isSpecialRuntimePermission(final String permission) {
-        return false;
+        return Manifest.permission.INTERNET.equals(permission);
     }
 
     /**

--- a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
+++ b/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
@@ -855,6 +855,10 @@ public class PermissionManagerService {
         }
     }
 
+    public static boolean isSpecialRuntimePermission(final String permission) {
+        return false;
+    }
+
     /**
      * Restore the permission state for a package.
      *
@@ -1279,7 +1283,13 @@ public class PermissionManagerService {
                                              wasChanged = true;
                                         }
                                     }
-                                } else {
+                                } else if (isSpecialRuntimePermission(bp.name) &&
+					origPermissions.getRuntimePermissionState(bp.name, userId) == null) {
+                                    if (permissionsState.grantRuntimePermission(bp, userId)
+                                            != PERMISSION_OPERATION_FAILURE) {
+                                        wasChanged = true;
+                                    }
+				} else {
                                     if (!permissionsState.hasRuntimePermission(bp.name, userId)
                                             && permissionsState.grantRuntimePermission(bp,
                                                     userId) != PERMISSION_OPERATION_FAILURE) {
@@ -2060,7 +2070,7 @@ public class PermissionManagerService {
                     && (grantedPermissions == null
                            || ArrayUtils.contains(grantedPermissions, permission))) {
                 final int flags = permissionsState.getPermissionFlags(permission, userId);
-                if (supportsRuntimePermissions) {
+                if (supportsRuntimePermissions || isSpecialRuntimePermission(bp.name)) {
                     // Installer cannot change immutable permissions.
                     if ((flags & immutableFlags) == 0) {
                         grantRuntimePermission(permission, pkg.packageName, false, callingUid,
@@ -2118,7 +2128,7 @@ public class PermissionManagerService {
         // to keep the review required permission flag per user while an
         // install permission's state is shared across all users.
         if (pkg.applicationInfo.targetSdkVersion < Build.VERSION_CODES.M
-                && bp.isRuntime()) {
+                && bp.isRuntime() && !isSpecialRuntimePermission(bp.name)) {
             return;
         }
 
@@ -2170,7 +2180,8 @@ public class PermissionManagerService {
                     + permName + " for package " + packageName);
         }
 
-        if (pkg.applicationInfo.targetSdkVersion < Build.VERSION_CODES.M) {
+        if (pkg.applicationInfo.targetSdkVersion < Build.VERSION_CODES.M
+                && !isSpecialRuntimePermission(permName)) {
             Slog.w(TAG, "Cannot grant runtime permission to a legacy app");
             return;
         }
@@ -2256,7 +2267,7 @@ public class PermissionManagerService {
         // to keep the review required permission flag per user while an
         // install permission's state is shared across all users.
         if (pkg.applicationInfo.targetSdkVersion < Build.VERSION_CODES.M
-                && bp.isRuntime()) {
+                && bp.isRuntime() && !isSpecialRuntimePermission(permName)) {
             return;
         }
 


### PR DESCRIPTION
Not yet tested... I am not super confident that the special runtime permissions will work as intended, as PermissionManagerService.java changed a lot from pie to 10.

Ref: https://github.com/GrapheneOS/platform_packages_apps_PackageInstaller/pull/2