### PR TITLE
Make Manifest.permission_group.NETWORK findable

### DIFF
--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -1507,9 +1507,7 @@
     <!-- ======================================= -->
     <eat-comment />
 
-    <!-- Network access
-         @hide
-    -->
+    <!-- Network access -->
     <permission-group android:name="android.permission-group.NETWORK"
         android:icon="@drawable/perm_group_network"
         android:label="@string/permgrouplab_network"


### PR DESCRIPTION
Fixes build issues related to Manifest.permission_group.NETWORK not being found.