### PR TITLE
add seedvault as default backup provider and enable backup functionality

### DIFF
--- a/packages/SettingsProvider/res/values/defaults.xml
+++ b/packages/SettingsProvider/res/values/defaults.xml
@@ -51,8 +51,8 @@
     <bool name="def_wifi_wakeup_enabled">true</bool>
     <bool name="def_networks_available_notification_on">true</bool>
 
-    <bool name="def_backup_enabled">false</bool>
-    <string name="def_backup_transport" translatable="false">com.android.localtransport/.LocalTransport</string>
+    <bool name="def_backup_enabled">true</bool>
+    <string name="def_backup_transport" translatable="false">com.stevesoltys.seedvault.transport.ConfigurableBackupTransport</string>
 
     <!-- Default value for whether or not to pulse the notification LED when there is a
          pending notification -->

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
@@ -3238,7 +3238,7 @@ public class SettingsProvider extends ContentProvider {
         }
 
         private final class UpgradeController {
-            private static final int SETTINGS_VERSION = 183;
+            private static final int SETTINGS_VERSION = 184;
 
             private final int mUserId;
 
@@ -4447,6 +4447,33 @@ public class SettingsProvider extends ContentProvider {
                             true /* makeDefault */, SettingsState.SYSTEM_PACKAGE_NAME);
 
                     currentVersion = 183;
+                }
+
+                if (currentVersion == 183) {
+                    // Version 184: Update default Backup app to Seedvault
+                    final SettingsState secureSettings = getSecureSettingsLocked(userId);
+                    Setting currentBackupTransportSetting = secureSettings.getSettingLocked(
+                            Secure.BACKUP_TRANSPORT);
+                    if (currentBackupTransportSetting.isDefaultFromSystem()) {
+                        secureSettings.insertSettingLocked(
+                                Settings.Secure.BACKUP_TRANSPORT,
+                                getContext().getResources().getString(
+                                        R.string.def_backup_transport),
+                                null, true,
+                                SettingsState.SYSTEM_PACKAGE_NAME);
+                    }
+
+                    Setting currentBackupEnabledSetting = secureSettings.getSettingLocked(
+                            Secure.BACKUP_ENABLED);
+                    if (currentBackupEnabledSetting.isDefaultFromSystem()) {
+                        secureSettings.insertSettingLocked(
+                                Settings.Secure.BACKUP_ENABLED,
+                                getContext().getResources().getBoolean(
+                                        R.bool.def_backup_enabled)? "1" : "0",
+                                null, true,
+                                SettingsState.SYSTEM_PACKAGE_NAME);
+                    }
+                    currentVersion = 184;
                 }
 
                 // vXXX: Add new settings above this point.


### PR DESCRIPTION
prebuilt apk package can be found in https://github.com/renlord/seedvault-prebuilt.

To setup AOSP source tree without `repo` manually, clone my git repository into `external/Seedvault`, then build.

Please migrate my repo into Graphene OS to update manifest.

Closes https://github.com/GrapheneOS/os_issue_tracker/issues/25

Also just to elaborate why both Soong/Kati build scripts are used:

Since Android Q introduced the `/product` partition, the `LOCAL_PRODUCT_MODULE := true` flag is supposedly meant to allow installation of src files into the `/product` partitition, but for some reason toggling this flag for modules with the `ETC` class does not install the ETC modules source files into the product partition when using Kati, hence the usage of Soong `Android.bp`. Anyways, ideally everything should be migrated to Soong.