### PR TITLE
Globally (not just in US) opt out of Safe Volume misfeature

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2609,7 +2609,7 @@
     <bool name="config_useDevInputEventForAudioJack">false</bool>
 
     <!-- Whether safe headphone volume is enabled or not (country specific). -->
-    <bool name="config_safe_media_volume_enabled">true</bool>
+    <bool name="config_safe_media_volume_enabled">false</bool>
 
     <!-- Whether safe headphone volume warning dialog is disabled on Vol+ (operator specific). -->
     <bool name="config_safe_media_disable_on_volume_up">true</bool>


### PR DESCRIPTION
Safe Volume has many false alarms. And if overridden by the user, at every 20 hours of accumulated(!) audio playback it will intentionally reset - even while the audio is playing. This can ruin the listening experience, and ironically pose a safety hazard when e.g. the user is operating a vehicle...

AOSP already opted out of Safe Volume in the overlays for Mobile Country Code 310-316 (= US). Make this universal.