### PR TITLE
show hidden logout button and allow system user logout

### DIFF
--- a/core/java/android/app/IActivityManager.aidl
+++ b/core/java/android/app/IActivityManager.aidl
@@ -344,6 +344,8 @@ interface IActivityManager {
     @UnsupportedAppUsage
     int stopUser(int userid, boolean force, in IStopUserCallback callback);
     @UnsupportedAppUsage
+    int restartSystemUserInForegroundIfCurrent();
+    @UnsupportedAppUsage
     void registerUserSwitchObserver(in IUserSwitchObserver observer, in String name);
     void unregisterUserSwitchObserver(in IUserSwitchObserver observer);
     int[] getRunningUserIds();

--- a/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java
+++ b/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java
@@ -730,8 +730,12 @@ public class GlobalActionsDialog implements DialogInterface.OnDismissListener,
             mHandler.postDelayed(() -> {
                 try {
                     int currentUserId = getCurrentUser().id;
-                    ActivityManager.getService().switchUser(UserHandle.USER_SYSTEM);
-                    ActivityManager.getService().stopUser(currentUserId, true /*force*/, null);
+                    if (currentUserId == UserHandle.USER_SYSTEM) {
+                        ActivityManager.getService().restartSystemUserInForegroundIfCurrent();
+                    } else {
+                        ActivityManager.getService().switchUser(UserHandle.USER_SYSTEM);
+                        ActivityManager.getService().stopUser(currentUserId, true /*force*/, null);
+                    }
                 } catch (RemoteException re) {
                     Log.e(TAG, "Couldn't logout user " + re);
                 }

--- a/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java
+++ b/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java
@@ -389,8 +389,7 @@ public class GlobalActionsDialog implements DialogInterface.OnDismissListener,
             } else if (GLOBAL_ACTION_KEY_SCREENSHOT.equals(actionKey)) {
                 mItems.add(new ScreenshotAction());
             } else if (GLOBAL_ACTION_KEY_LOGOUT.equals(actionKey)) {
-                if (mDevicePolicyManager.isLogoutEnabled()
-                        && getCurrentUser().id != UserHandle.USER_SYSTEM) {
+                if (shouldDisplayLogout()) {
                     mItems.add(new LogoutAction());
                     mHasLogoutButton = true;
                 }
@@ -451,6 +450,15 @@ public class GlobalActionsDialog implements DialogInterface.OnDismissListener,
         int state = mLockPatternUtils.getStrongAuthForUser(userId);
         return (state == STRONG_AUTH_NOT_REQUIRED
                 || state == SOME_AUTH_REQUIRED_AFTER_USER_REQUEST);
+    }
+
+    private boolean shouldDisplayLogout() {
+        int userId = getCurrentUser().id;
+        // Logout is meaningless if not secure. Logging out system user isn't supported
+        // at the moment, as the system user has no where to go after logging out and there
+        // are many things to test.
+        return mKeyguardManager.isDeviceSecure(userId)
+                && getCurrentUser().id != UserHandle.USER_SYSTEM;
     }
 
     @Override

--- a/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java
+++ b/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java
@@ -457,8 +457,7 @@ public class GlobalActionsDialog implements DialogInterface.OnDismissListener,
         // Logout is meaningless if not secure. Logging out system user isn't supported
         // at the moment, as the system user has no where to go after logging out and there
         // are many things to test.
-        return mKeyguardManager.isDeviceSecure(userId)
-                && getCurrentUser().id != UserHandle.USER_SYSTEM;
+        return mKeyguardManager.isDeviceSecure(userId);
     }
 
     @Override

--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -17578,6 +17578,15 @@ public class ActivityManagerService extends IActivityManager.Stub
         return mUserController.stopUser(userId, force, callback, null /* keyEvictedCallback */);
     }
 
+    /**
+     * Restarts the system user if it is the current user. Used to logout and evict
+     * the system user's credential keys.
+     */
+    @Override
+    public int restartSystemUserInForegroundIfCurrent() {
+        return mUserController.restartSystemUserInForegroundIfCurrent(null);
+    }
+
     @Override
     public UserInfo getCurrentUser() {
         return mUserController.getCurrentUser();

--- a/services/core/java/com/android/server/am/UserController.java
+++ b/services/core/java/com/android/server/am/UserController.java
@@ -645,8 +645,8 @@ class UserController implements Handler.Callback {
                 keyEvictedCallback = new KeyEvictedCallback() {
                     @Override
                     public void keyEvicted(@UserIdInt int userId) {
-                        Slog.d(TAG, "DEBUG: System user key evicted; starting up again.");
-                        // Start the user up and bring to the foreground.
+                        Slog.d(TAG, "user 0 key evicted; starting up again.");
+                        // Start the system user back up and bring to the foreground.
                         // Post to the same handler that this callback is called from to ensure the
                         // user cleanup is complete before restarting.
                         mHandler.post(() -> UserController.this.startUser(userId, true));
@@ -671,7 +671,11 @@ class UserController implements Handler.Callback {
     private int stopUsersLU(final int userId, boolean force,
             final IStopUserCallback stopUserCallback, KeyEvictedCallback keyEvictedCallback) {
         if (isCurrentUserLU(userId)) {
-            return USER_OP_IS_CURRENT;
+            // Allow logging out of the system user, but verify that there must
+            // be a KeyEvictedCallback, or else the user will be locked out.
+            if (userId != UserHandle.USER_SYSTEM || keyEvictedCallback == null) {
+                return USER_OP_IS_CURRENT;
+            }
         }
         int[] usersToStop = getUsersToStopLU(userId);
         // If one of related users is system or current, no related users should be stopped

--- a/services/core/java/com/android/server/am/UserController.java
+++ b/services/core/java/com/android/server/am/UserController.java
@@ -155,6 +155,20 @@ class UserController implements Handler.Callback {
     // when it never calls back.
     private static final int USER_SWITCH_CALLBACKS_TIMEOUT_MS = 5 * 1000;
 
+    // For logging out of the system user and having it start up again in the foreground after.
+    private final KeyEvictedCallback START_SYSTEM_USER_FOREGROUND_KEY_EVICTED_CALLBACK =
+            new KeyEvictedCallback() {
+                @Override
+                public void keyEvicted(int userId) {
+                    Slog.d(TAG, "user 0 key evicted; starting up again.");
+                    // Start the system user back up and bring to the foreground.
+                    // Post to the same handler that this callback is called from to ensure the
+                    // user cleanup is complete before restarting.
+                    mHandler.post(() -> UserController.this.startUser(
+                            UserHandle.USER_SYSTEM, true));
+                }
+            };
+
     /**
      * Maximum number of users we allow to be running at a time, including system user.
      *
@@ -639,21 +653,14 @@ class UserController implements Handler.Callback {
             throw new IllegalArgumentException("Can't stop user " + userId);
         }
         if (userId == UserHandle.USER_SYSTEM) {
+            // Allow logging out of the system user.
+            // When logging out, stopUser is expected to be called from the
+            // ActivityManagerService with a null keyEvictedCallback.
             if (isCurrentUserLU(UserHandle.USER_SYSTEM) && keyEvictedCallback == null) {
-                // Logging out of the system user, so if we don't start up USER_SYSTEM again,
-                // then the phone will be a blank screen.
-                keyEvictedCallback = new KeyEvictedCallback() {
-                    @Override
-                    public void keyEvicted(@UserIdInt int userId) {
-                        Slog.d(TAG, "user 0 key evicted; starting up again.");
-                        // Start the system user back up and bring to the foreground.
-                        // Post to the same handler that this callback is called from to ensure the
-                        // user cleanup is complete before restarting.
-                        mHandler.post(() -> UserController.this.startUser(userId, true));
-                    }
-                };
+                // If we don't start up USER_SYSTEM again,
+                // then the phone will be a blank screen after logging out.
+                keyEvictedCallback = START_SYSTEM_USER_FOREGROUND_KEY_EVICTED_CALLBACK;
             } else {
-                // If keyEvictedCallback not null, then we're not logging out.
                 throw new IllegalArgumentException("Can't stop system user " + userId);
             }
         }
@@ -670,16 +677,27 @@ class UserController implements Handler.Callback {
     @GuardedBy("mLock")
     private int stopUsersLU(final int userId, boolean force,
             final IStopUserCallback stopUserCallback, KeyEvictedCallback keyEvictedCallback) {
+        // If trying to stop system user, verify that there must
+        // be the right KeyEvictedCallback, or else the user will be locked out.
+        if (userId == UserHandle.USER_SYSTEM
+                && keyEvictedCallback != START_SYSTEM_USER_FOREGROUND_KEY_EVICTED_CALLBACK) {
+            return USER_OP_ERROR_IS_SYSTEM;
+        }
         if (isCurrentUserLU(userId)) {
-            // Allow logging out of the system user, but verify that there must
-            // be a KeyEvictedCallback, or else the user will be locked out.
-            if (userId != UserHandle.USER_SYSTEM || keyEvictedCallback == null) {
+            // If logging out of system user, the current user will be the system user,
+            // since we assume system user has no users to switch to.
+            if (userId != UserHandle.USER_SYSTEM) {
                 return USER_OP_IS_CURRENT;
             }
         }
         int[] usersToStop = getUsersToStopLU(userId);
         // If one of related users is system or current, no related users should be stopped
         for (int i = 0; i < usersToStop.length; i++) {
+            if (UserHandle.USER_SYSTEM == userId) {
+                // Skip checking if trying to logout of system user.
+                break;
+            }
+
             int relatedUserId = usersToStop[i];
             if ((UserHandle.USER_SYSTEM == relatedUserId) || isCurrentUserLU(relatedUserId)) {
                 if (DEBUG_MU) Slog.i(TAG, "stopUsersLocked cannot stop related user "
@@ -694,7 +712,7 @@ class UserController implements Handler.Callback {
                 return USER_OP_ERROR_RELATED_USERS_CANNOT_STOP;
             }
         }
-        if (DEBUG_MU) Slog.i(TAG, "stopUsersLocked usersToStop=" + Arrays.toString(usersToStop));
+        if (DEBUG_MU || true) Slog.i(TAG, "stopUsersLocked usersToStop=" + Arrays.toString(usersToStop));
         for (int userIdToStop : usersToStop) {
             stopSingleUserLU(userIdToStop,
                     userIdToStop == userId ? stopUserCallback : null,


### PR DESCRIPTION
Fixes https://github.com/GrapheneOS/os_issue_tracker/issues/258

Exposes the logout button in the power menu already built into the operating system and allows for logging out of the system/admin user. This logout button should evict the credential keys for the user. If the user being logged out is not the system/admin user, it will switch to the system user and then stop the user.

Logging out of the system user is not originally supported by the operating system as seen from all these checks in UserController. 
- Instead of modifying the original logic (there are a lot of checks to make sure the system user isn't being logged out), new methods that follow the original methods are used to logout of the system user. This is done to keep things compatible with previous code, and to only allow stopping the system user when the user explicitly presses the logout button.
- A KeyEvictedCallback is used to restart the system user after it has been stopped and cleaned up. If we don't do it that way, then the screen will be blank after the system user stops.