### PR TITLE
have NfcTile get an NfcAdapter directly

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/NfcTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/NfcTile.java
@@ -161,7 +161,7 @@ public class NfcTile extends QSTileImpl<BooleanState> {
     private NfcAdapter getAdapter() {
         if (mAdapter == null) {
             try {
-                mAdapter = NfcAdapter.getDefaultAdapter(mContext);
+                mAdapter = NfcAdapter.getNfcAdapter(mContext.getApplicationContext());
             } catch (UnsupportedOperationException e) {
                 mAdapter = null;
             }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os_issue_tracker/issues/324

This changes the NfcTile to not be dependent on an NfcManager giving the
NfcTile an NfcAdapter.

The problem with NfcTile is that the NfcService doesn't start until the
device is unlocked after a reboot, but NfcTile can be created and have
its state updated before the device is unlocked.

The state of NfcTile depends on an NfcAdapter. The tile gets an
NfcAdapter from a call to NfcAdapter#getDefaultAdapter, which gets an
adapter from an NfcManager via Context#getSystemService, and NfcManager
tries to get an adapter in its constructor via NfcAdapter#getNfcAdapter.

If this is done before unlock, NfcService isn't started, so the
constructor of NfcManager fails to get an adapter, opting to just store
null. This means that the NfcManager that's _cached_ by the NfcTile's
application context holds a null NfcAdapter, so subsequent calls in
NfcTile to get the NfcAdapter will keep returning null.

We can just have NfcTile get the NfcAdapter directly via
NfcAdapter#getNfcAdapter instead of relying on an NfcManager to call the
same method for us to get its default adapter. We just have to make sure
we use the application context for NfcAdapter#getNfcAdapter, as per the
doc comments for getNfcAdapter. This means that there's no longer an
NfcManager associated with the NfcTile's application context.

It doesn't look like NfcManager does anything special with the
NfcAdapter anyway. It seems to just be some middle man for NfcAdapters:
* The NfcAdapter field in NfcManager is final, and it doesn't do
anything else with it besides have a getter method for returning it. The
NfcManager seems to be a way to force third-party apps that want to get
an NfcAdapter to use the application context.
* NfcAdapter#getNfcAdapter manages the caching of NfcAdapters by
application context in a static HashMap. NfcManager doesn't manage
caching; it just calls NfcAdapter#getNfcAdapter.