### PR TITLE
fix SystemUI crash from null stored in non-nullable

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/media/MediaDataManager.kt
+++ b/packages/SystemUI/src/com/android/systemui/media/MediaDataManager.kt
@@ -360,7 +360,9 @@ class MediaDataManager(
         val app = builder.loadHeaderAppName()
 
         // App Icon
-        val smallIconDrawable: Drawable = sbn.notification.smallIcon.loadDrawable(context)
+        // TODO: Look into why context is not for the right user. If current user is a secondary
+        //  user, context.userId is still 0, not the id of the current user.
+        val smallIconDrawable: Drawable? = sbn.notification.smallIcon.loadDrawable(context)
 
         // Song name
         var song: CharSequence? = metadata.getString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE)


### PR DESCRIPTION
Fixes https://github.com/GrapheneOS/os_issue_tracker/issues/339

The fatal crash for SystemUI is caused by a null being stored in a non-null type, resulting in a fatal exception:

```plain
10-04 11:43:42.336 21999 22045 E Icon    : Unable to find pkg=com.spotify.music for icon Icon(typ=RESOURCE pkg=com.spotify.music id=0x7f080347)
10-04 11:43:42.336 21999 22045 E Icon    : android.content.pm.PackageManager: com.spotify.music
10-04 11:43:42.336 21999 22045 E Icon    : at android.app.ApplicationPackageManager.getApplicationInfoAsUser(ApplicationPackageManager.java:423)
10-04 11:43:42.336 21999 22045 E Icon    : at android.app.ApplicationPackageManager.getApplicationInfo(ApplicationPackageManager.java:412)
10-04 11:43:42.336 21999 22045 E Icon    : at android.graphics.drawable.Icon.loadDrawableInner(Icon.java:366)
10-04 11:43:42.336 21999 22045 E Icon    : at android.graphics.drawable.Icon.loadDrawable(Icon.java:334)
10-04 11:43:42.336 21999 22045 E Icon    : at com.android.systemui.media.MediaDataManager.loadMediaDataInBg(MediaDataManager.kt:363)
10-04 11:43:42.336 21999 22045 E Icon    : at com.android.systemui.media.MediaDataManager.access(MediaDataManager.kt:89)
10-04 11:43:42.336 21999 22045 E Icon    : at com.android.systemui.media.MediaDataManager.run(MediaDataManager.kt:241)
10-04 11:43:42.336 21999 22045 E Icon    : at android.os.Handler.handleCallback(Handler.java:938)
10-04 11:43:42.336 21999 22045 E Icon    : at android.os.Handler.dispatchMessage(Handler.java:99)
10-04 11:43:42.336 21999 22045 E Icon    : at android.os.Looper.loop(Looper.java:223)
10-04 11:43:42.336 21999 22045 E Icon    : at android.os.HandlerThread.run(HandlerThread.java:67)
10-04 11:43:42.337 21999 22045 E AndroidRuntime: FATAL EXCEPTION: SysUiBg
10-04 11:43:42.337 21999 22045 E AndroidRuntime: Process: com.android.systemui, PID: 21999
10-04 11:43:42.337 21999 22045 E AndroidRuntime: java.lang.IllegalStateException: sbn.notification.smallIcon.loadDrawable(context) must not be null
10-04 11:43:42.337 21999 22045 E AndroidRuntime: at com.android.systemui.media.MediaDataManager.loadMediaDataInBg(MediaDataManager.kt:363)
10-04 11:43:42.337 21999 22045 E AndroidRuntime: at com.android.systemui.media.MediaDataManager.access(MediaDataManager.kt:89)
10-04 11:43:42.337 21999 22045 E AndroidRuntime: at com.android.systemui.media.MediaDataManager.run(MediaDataManager.kt:241)
10-04 11:43:42.337 21999 22045 E AndroidRuntime: at android.os.Handler.handleCallback(Handler.java:938)
10-04 11:43:42.337 21999 22045 E AndroidRuntime: at android.os.Handler.dispatchMessage(Handler.java:99)
10-04 11:43:42.337 21999 22045 E AndroidRuntime: at android.os.Looper.loop(Looper.java:223)
10-04 11:43:42.337 21999 22045 E AndroidRuntime: at android.os.HandlerThread.run(HandlerThread.java:67)
10-04 11:43:42.341  1345 22098 I DropBoxManagerService: add tag=system_app_crash isTagEnabled=true flags=0x2
10-04 11:43:42.341  1345  2468 W ActivityManager: Process com.android.systemui has crashed too many times: killing!
10-04 11:43:42.342  1345  1546 W ActivityManager: Skipping crash dialog of ProcessRecord{d35b54a 21999:com.android.systemui/u0a108}: background
10-04 11:43:42.343 21999 22045 I Process : Sending signal. PID: 21999 SIG: 9
```

This seems to have happened from mixing Java and Kotlin code without marking loadDrawable in Java as Nullable. We could mark loadDrawable with a `@Nullable` annotation, but that requires an API change, so it might break other things if they don't check for this case. Something like that would probably best be done upstream.

For some reason, the Context used in the call is for user 0. So, if user 0 doesn't have the package for an app providing media notifications, it will return null, since it can't get the Drawable. (e.g., Try installing NewPipe in a secondary user and make sure NewPipe is not installed in the system user. Then, play a video without this commit applied.) Oddly enough, this doesn't seem to break the icons for these media notifications.

We should just make the Drawable type for `smallIconDrawable` nullable to prevent this fatal exception. The variable is only used in the constructor for MediaData which [can accept a nullable Drawable in its constructor](https://github.com/GrapheneOS/platform_frameworks_base/blob/11/packages/SystemUI/src/com/android/systemui/media/MediaData.kt#L36), and whatever uses that icon in MediaData it does [appropriate null checks](https://github.com/GrapheneOS/platform_frameworks_base/blob/11/packages/SystemUI/src/com/android/systemui/media/MediaControlPanel.java#L223)

There's some other icon-related exceptions stemming from PackageManager.NameNotFoundException as detailed in the issue, but this at least cleans up the crashing of SystemUI which is what the original issue is essentially about.