### PR TITLE
switch to providing WebView via Vanadium

### DIFF
--- a/core/res/res/xml/config_webview_packages.xml
+++ b/core/res/res/xml/config_webview_packages.xml
@@ -16,6 +16,6 @@
 
 <webviewproviders>
     <!-- The default WebView implementation -->
-    <webviewprovider description="Android WebView" packageName="com.google.android.webview" availableByDefault="true">
+    <webviewprovider description="Vanadium" packageName="org.grapheneos.vanadium.webview" availableByDefault="true">
     </webviewprovider>
 </webviewproviders>


### PR DESCRIPTION
Opening PDF Viewer, I was able to browse PDFs, and I see this in logcat:

```
10-06 12:18:42.353  3797  3797 I WebViewFactory: Loading org.grapheneos.vanadium.webview version 86.0.4240.75 (code 424007534)
```

Also used a browser app that uses WebView without problems