### PR TITLE
bugfix: authenticated timestamp cert validation

### DIFF
--- a/core/java/android/net/SntpClient.java
+++ b/core/java/android/net/SntpClient.java
@@ -37,10 +37,21 @@ import javax.net.ssl.HttpsURLConnection;
 
 import java.security.cert.X509Certificate;
 
+import java.util.Date;
+import java.util.Set;
+import java.math.BigInteger;
 import java.security.KeyStore;
+import java.security.Principal;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.security.NoSuchProviderException;
+import java.security.InvalidKeyException;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
+
 
 import static android.os.Build.TIME;
 
@@ -58,7 +69,7 @@ import static android.os.Build.TIME;
  */
 public class SntpClient {
     private static final String TAG = "SntpClient";
-    private static final boolean DBG = true;
+    private static final boolean DBG = false;
 
     private static final int REFERENCE_TIME_OFFSET = 16;
     private static final int ORIGINATE_TIME_OFFSET = 24;
@@ -142,7 +153,7 @@ public class SntpClient {
             network.bindSocket(socket);
             socket.setSoTimeout(timeout);
             byte[] buffer = new byte[NTP_PACKET_SIZE];
-            DatagramPacket request = new DatagramPacket(buffer, buffer.length, address, port);
+           DatagramPacket request = new DatagramPacket(buffer, buffer.length, address, port);
 
             // set mode = 3 (client) and version = 3
             // mode is in low 3 bits of first byte
@@ -213,6 +224,7 @@ public class SntpClient {
         final int oldTag = TrafficStats.getAndSetThreadStatsTag(
                 TrafficStatsConstants.TAG_SYSTEM_NTP);
         final Network networkForResolv = network.getPrivateDnsBypassingCopy();
+        if (DBG) Log.d(TAG, "requestHttpTime() getting time using https");
         try {
             TrustManagerFactory tmf = TrustManagerFactory
                 .getInstance(TrustManagerFactory.getDefaultAlgorithm());
@@ -228,48 +240,180 @@ public class SntpClient {
 
             final X509TrustManager finalTm = x509Tm;
             X509TrustManager customTm = new X509TrustManager() {
+
+                // custom eternal certificate class that ignores expired SSL certificates
+                // adapted from https://gist.github.com/divergentdave/9a68d820e3610513bd4fcdc4ae5f91a1
+                class TimeLeewayCertificate extends X509Certificate {
+                    private final X509Certificate originalCertificate;
+
+                    public TimeLeewayCertificate(X509Certificate originalCertificate) {
+                        this.originalCertificate = originalCertificate;
+                    }
+
+                    @Override
+                    public void checkValidity() throws CertificateExpiredException, CertificateNotYetValidException {
+                        // Ignore notBefore/notAfter
+                        checkValidity(new Date());
+                    }
+
+                    @Override
+                    public void checkValidity(Date date) throws CertificateExpiredException, CertificateNotYetValidException {
+                        // expiration must be set after OS build date
+                        if (getNotAfter().compareTo(new Date(TIME)) < 0) {
+                            throw new CertificateExpiredException("Certificate expired at "
+                                    + getNotAfter().toString() + " (compared to " + date.toString() + ")");
+                        }
+                    }
+
+                    @Override
+                    public int getVersion() {
+                        return originalCertificate.getVersion();
+                    }
+
+                    @Override
+                    public BigInteger getSerialNumber() {
+                        return originalCertificate.getSerialNumber();
+                    }
+
+                    @Override
+                    public Principal getIssuerDN() {
+                        return originalCertificate.getIssuerDN();
+                    }
+
+                    @Override
+                    public Principal getSubjectDN() {
+                        return originalCertificate.getSubjectDN();
+                    }
+
+                    @Override
+                    public Date getNotBefore() {
+                        return originalCertificate.getNotBefore();
+                    }
+
+                    @Override
+                    public Date getNotAfter() {
+                        return originalCertificate.getNotAfter();
+                    }
+
+                    @Override
+                    public byte[] getTBSCertificate() throws CertificateEncodingException {
+                        return originalCertificate.getTBSCertificate();
+                    }
+
+                    @Override
+                    public byte[] getSignature() {
+                        return originalCertificate.getSignature();
+                    }
+
+                    @Override
+                    public String getSigAlgName() {
+                        return originalCertificate.getSigAlgName();
+                    }
+
+                    @Override
+                    public String getSigAlgOID() {
+                        return originalCertificate.getSigAlgOID();
+                    }
+
+                    @Override
+                    public byte[] getSigAlgParams() {
+                        return originalCertificate.getSigAlgParams();
+                    }
+
+                    @Override
+                    public boolean[] getIssuerUniqueID() {
+                        return originalCertificate.getIssuerUniqueID();
+                    }
+
+                    @Override
+                    public boolean[] getSubjectUniqueID() {
+                        return originalCertificate.getSubjectUniqueID();
+                    }
+
+                    @Override
+                    public boolean[] getKeyUsage() {
+                        return originalCertificate.getKeyUsage();
+                    }
+
+                    @Override
+                    public int getBasicConstraints() {
+                        return originalCertificate.getBasicConstraints();
+                    }
+
+                    @Override
+                    public byte[] getEncoded() throws CertificateEncodingException {
+                        return originalCertificate.getEncoded();
+                    }
+
+                    @Override
+                    public void verify(PublicKey key) throws CertificateException,
+                           NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException 
+                    {
+                        originalCertificate.verify(key);
+                    }
+
+                    @Override
+                    public void verify(PublicKey key, String sigProvider) throws CertificateException,
+                           NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException 
+                    {
+                        originalCertificate.verify(key, sigProvider);
+                    }
+
+                    @Override
+                    public String toString() {
+                        return originalCertificate.toString();
+                    }
+
+                    @Override
+                    public PublicKey getPublicKey() {
+                        return originalCertificate.getPublicKey();
+                    }
+
+                    @Override
+                    public Set<String> getCriticalExtensionOIDs() {
+                        return originalCertificate.getCriticalExtensionOIDs();
+                    }
+
+                    @Override
+                    public byte[] getExtensionValue(String oid) {
+                        return originalCertificate.getExtensionValue(oid);
+                    }
+
+                    @Override
+                    public Set<String> getNonCriticalExtensionOIDs() {
+                        return originalCertificate.getNonCriticalExtensionOIDs();
+                    }
+
+                    @Override
+                    public boolean hasUnsupportedCriticalExtension() {
+                        return originalCertificate.hasUnsupportedCriticalExtension();
+                    }
+                }
+
                 @Override
                 public X509Certificate[] getAcceptedIssuers() {
                     return finalTm.getAcceptedIssuers();
                 }
 
                 @Override
-                public void checkServerTrusted(X509Certificate[] chain,
-                        String authType) throws CertificateException {
-                    try {
-                        finalTm.checkServerTrusted(chain, authType);
-                    } catch (CertificateException e) {
-                        // deliberately catch certificate time checks to prevent
-                        // propogating to SSLHandshake Error only when getting
-                        // authenticated timestamps.
-                        final Throwable validationFailCause = e.getCause();
-                        if (validationFailCause instanceof CertificateNotYetValidException ||
-                                validationFailCause instanceof CertificateExpiredException) {
-                            return;
+                public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                        // replace the top-level certificate with a certificate validation routine that
+                        // ignores expired certificates due to clock drift.
+                        X509Certificate[] timeLeewayChain = new X509Certificate[chain.length];
+                        for (int i = 0; i < chain.length; i++) {
+                            timeLeewayChain[i] = new TimeLeewayCertificate(chain[i]);
                         }
-                        throw e;
-                    }
+                        finalTm.checkServerTrusted(timeLeewayChain, authType);
                 }
 
                 @Override
-                public void checkClientTrusted(X509Certificate[] chain,
-                        String authType) throws CertificateException {
-                    try {
-                        finalTm.checkClientTrusted(chain, authType);
-                    } catch (CertificateException e) {
-                        // deliberately catch certificate time checks to prevent
-                        // propogating to SSLHandshake Error only when getting
-                        // authenticated timestamps.
-                        final Throwable validationFailCause = e.getCause();
-                        if (validationFailCause instanceof CertificateNotYetValidException ||
-                                validationFailCause instanceof CertificateExpiredException) {
-                            return;
-                        }
-                        throw e;
-                    }
+                public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                    // never gets used, so default to stock.
+                    finalTm.checkClientTrusted(chain, authType);
                 }
             };
 
+            if (DBG) Log.d(TAG, "requestHttpTime() setting up URL connection");
             URLConnection urlConnection = networkForResolv.openConnection(url);
             SSLContext sslContext = SSLContext.getInstance("SSL");
             sslContext.init(null, new TrustManager[] { customTm }, null);
@@ -307,6 +451,9 @@ public class SntpClient {
                     mNtpTime = responseTime + clockOffset;
                     mNtpTimeReference = responseTicks;
                     mRoundTripTime = roundTripTime;
+                } catch (Exception e) {
+                    Log.e(TAG, "request https time failed: " + e.toString());
+                    if (DBG) e.printStackTrace();
                 } finally {
                     httpsUrlConnection.disconnect();
                 }
@@ -317,7 +464,10 @@ public class SntpClient {
             }
         } catch (Exception e) {
             EventLogTags.writeNtpFailure(url.toString(), e.toString());
-            if (DBG) Log.d(TAG, "request time failed: " + e);
+            Log.e(TAG, "request time failed: " + e.toString());
+            if (DBG) {
+                e.printStackTrace();
+            }
             return false;
         } finally {
             TrafficStats.setThreadStatsTag(oldTag);


### PR DESCRIPTION
Replaces the standard X509Certificate class with a custom class that suppresses conventional date validity checks.
Instead the only date check that is done is to check if a certificate was created and valid after the OS build date.