### PR TITLE
allow backup capability for non owner user.

### DIFF
--- a/services/backup/java/com/android/server/backup/BackupManagerService.java
+++ b/services/backup/java/com/android/server/backup/BackupManagerService.java
@@ -291,12 +291,7 @@ public class BackupManagerService extends IBackupManager.Stub {
      * file exists.
      */
     private boolean isBackupActivatedForUser(int userId) {
-        if (getSuppressFileForSystemUser().exists()) {
-            return false;
-        }
-
-        return userId == UserHandle.USER_SYSTEM
-                || getActivatedFileForNonSystemUser(userId).exists();
+        return !getSuppressFileForSystemUser().exists();
     }
 
     protected Context getContext() {


### PR DESCRIPTION
By default after android Q AOSP does not allow backup for non owner user unless it get activated manually, and google setup wizard/GMS enables backup for non-owner profile if user add an google account.

as Graphene don't offer any account based backup service it's better to keep is turned on by default.