### PR TITLE
squash into 85bb8c3: quick fixup for fingerprint unlock

### DIFF
--- a/services/core/java/com/android/server/biometrics/BiometricService.java
+++ b/services/core/java/com/android/server/biometrics/BiometricService.java
@@ -874,8 +874,7 @@ public class BiometricService extends SystemService {
             mEnabledOnKeyguardCallbacks.add(new EnabledOnKeyguardCallback(callback));
             try {
                 callback.onChanged(BiometricSourceType.FINGERPRINT,
-                        mSettingObserver.getFingerprintEnabledOnKeyguard(),
-                        UserHandle.getCallingUserId());
+                        mSettingObserver.getFingerprintEnabledOnKeyguard(), callingUserId);
                 callback.onChanged(BiometricSourceType.FACE,
                         mSettingObserver.getFaceEnabledOnKeyguard(), callingUserId);
             } catch (RemoteException e) {


### PR DESCRIPTION
should be squashed into 85bb8c3

This feature was developed during Android 10 and`UserHandle.getCallingUserId()` was used in the Android 10 version, but I didn't change it to the Android 11 version which has a `callingUserId` passed to the callback. From testing, there's no functional difference between using `UserHandle.getCallingUserId()` and  using `callingUserId`, but this makes it more consistent with the upstream face unlock enabled setting.