### PR TITLE
Display UART notification on user builds

### DIFF
--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -385,6 +385,7 @@ import libcore.util.EmptyArray;
 
 import java.io.File;
 import java.io.FileDescriptor;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -405,6 +406,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -5568,8 +5570,29 @@ public class ActivityManagerService extends IActivityManager.Stub
         t.traceEnd();
     }
 
+    private static Boolean isUartEnabled()
+    {
+        // console=null should be set in the kernel cmdline when UART is off
+        final String console_string = "console=null";
+        boolean isEnabled = false;
+        try (Scanner sc = new Scanner(new FileInputStream("/proc/cmdline"))) {
+            StringBuilder scOutput = new StringBuilder();
+            while(sc.hasNextLine()){
+                scOutput.append(sc.nextLine());
+            }
+            isEnabled = !scOutput.toString().contains(console_string);
+        } catch (IOException ignored) {
+        }
+        // This check will only work on userdebug and eng builds due
+        // to the console service not being present on user builds.
+        if (SystemProperties.get("init.svc.console").equals("running")) {
+            isEnabled = true;
+        }
+        return isEnabled;
+    }
+
     private void showConsoleNotificationIfActive() {
-        if (!SystemProperties.get("init.svc.console").equals("running")) {
+        if (!isUartEnabled()) {
             return;
         }
         String title = mContext


### PR DESCRIPTION
The prior implementation relied on checking the init.svc.console prop,
however as the console service is never launched on a user build due to
it requiring ro.debuggable=1 , the UART notification will never appear.
If UART is enabled the kernel cmdline is changed so that console is no
longer null so use this to determine if UART is enabled and use the old
method as an additional check.