### PR TITLE
gmscompat: Improve foreground service notification UX

### DIFF
--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -73,23 +73,23 @@ public final class GmsHooks {
         return context.startForegroundService(service);
     }
 
-    private static void createFgsChannel(Service service) {
+    private static void createFgsChannel(Context context) {
         if (fgsChannelCreated) {
             return;
         }
 
         NotificationManager notificationManager = (NotificationManager)
-                service.getSystemService(Context.NOTIFICATION_SERVICE);
+                context.getSystemService(Context.NOTIFICATION_SERVICE);
 
         NotificationChannelGroup group = new NotificationChannelGroup(FGS_GROUP_ID,
-                service.getText(R.string.foreground_service_gmscompat_group));
+                context.getText(R.string.foreground_service_gmscompat_group));
         notificationManager.createNotificationChannelGroup(group);
 
-        CharSequence name = service.getText(R.string.foreground_service_gmscompat_channel);
+        CharSequence name = context.getText(R.string.foreground_service_gmscompat_channel);
         NotificationChannel channel = new NotificationChannel(FGS_CHANNEL_ID, name,
                 NotificationManager.IMPORTANCE_LOW);
         channel.setGroup(FGS_GROUP_ID);
-        channel.setDescription(service.getString(R.string.foreground_service_gmscompat_description));
+        channel.setDescription(context.getString(R.string.foreground_service_gmscompat_channel_desc));
         channel.setShowBadge(false);
         notificationManager.createNotificationChannel(channel);
 
@@ -107,12 +107,19 @@ public final class GmsHooks {
 
         // Channel
         createFgsChannel(service);
+
+        // Intent: notification channel settings
+        Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
+        intent.putExtra(Settings.EXTRA_APP_PACKAGE, service.getPackageName());
+        intent.putExtra(Settings.EXTRA_CHANNEL_ID, FGS_CHANNEL_ID);
+        PendingIntent pi = PendingIntent.getActivity(service, 0, intent, PendingIntent.FLAG_IMMUTABLE);
+
         // Notification
-        PendingIntent pi = PendingIntent.getActivity(service, 100, new Intent(),
-                PendingIntent.FLAG_IMMUTABLE);
+        CharSequence appName = service.getApplicationInfo().loadLabel(service.getPackageManager());
         Notification notification = new Notification.Builder(service, FGS_CHANNEL_ID)
                 .setSmallIcon(service.getApplicationInfo().icon)
-                .setContentTitle(service.getApplicationInfo().loadLabel(service.getPackageManager()))
+                .setContentTitle(service.getString(R.string.app_running_notification_title, appName))
+                .setContentText(service.getText(R.string.foreground_service_gmscompat_notif_desc))
                 .setContentIntent(pi)
                 .build();
 

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -21,6 +21,7 @@ import android.app.ActivityThread;
 import android.app.Application;
 import android.app.Notification;
 import android.app.NotificationChannel;
+import android.app.NotificationChannelGroup;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
@@ -38,6 +39,8 @@ import android.provider.Settings;
 import android.util.Log;
 import android.webkit.WebView;
 
+import com.android.internal.R;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -51,7 +54,8 @@ public final class GmsHooks {
     private static final String TAG = "GmsHooks";
 
     // Foreground service notifications
-    private static final String FGS_CHANNEL_ID = "service_shim";
+    private static final String FGS_GROUP_ID = "gmscompat_fgs_group";
+    private static final String FGS_CHANNEL_ID = "gmscompat_fgs_channel";
     private static final int FGS_NOTIFICATION_ID = 529977835;
     private static boolean fgsChannelCreated = false;
 
@@ -77,10 +81,16 @@ public final class GmsHooks {
         NotificationManager notificationManager = (NotificationManager)
                 service.getSystemService(Context.NOTIFICATION_SERVICE);
 
-        CharSequence name = service.getText(
-                com.android.internal.R.string.foreground_service_gms_shim_category);
+        NotificationChannelGroup group = new NotificationChannelGroup(FGS_GROUP_ID,
+                service.getText(R.string.foreground_service_gmscompat_group));
+        notificationManager.createNotificationChannelGroup(group);
+
+        CharSequence name = service.getText(R.string.foreground_service_gmscompat_channel);
         NotificationChannel channel = new NotificationChannel(FGS_CHANNEL_ID, name,
                 NotificationManager.IMPORTANCE_LOW);
+        channel.setGroup(FGS_GROUP_ID);
+        channel.setDescription(service.getString(R.string.foreground_service_gmscompat_description));
+        channel.setShowBadge(false);
         notificationManager.createNotificationChannel(channel);
 
         fgsChannelCreated = true;

--- a/core/res/res/values/strings.xml
+++ b/core/res/res/values/strings.xml
@@ -743,9 +743,12 @@
     <string name="foreground_service_gmscompat_channel">Services</string>
 
     <!-- Description for foreground service notification channel created by GmsCompat  -->
-    <string name="foreground_service_gmscompat_description">These notifications are created by the
+    <string name="foreground_service_gmscompat_channel_desc">These notifications are created by the
         Google Play Services compatibility layer in order to keep services running in the
         background.\n\nDisable this category to hide the unnecessary notifications.</string>
+
+    <!-- Description for foreground service notifications created by GmsCompat  -->
+    <string name="foreground_service_gmscompat_notif_desc">Tap to hide</string>
 
     <!-- Displayed to the user to tell them that they have started up the phone in "safe mode" -->
     <string name="safeMode">Safe mode</string>

--- a/core/res/res/values/strings.xml
+++ b/core/res/res/values/strings.xml
@@ -736,8 +736,16 @@
     <string name="foreground_service_multiple_separator"><xliff:g id="left_side">%1$s</xliff:g>,
         <xliff:g id="right_side">%2$s</xliff:g></string>
 
-    <!-- Name for foreground service notification category created by GmsCompat  -->
-    <string name="foreground_service_gms_shim_category">Services</string>
+    <!-- Name for foreground service notification channel group created by GmsCompat  -->
+    <string name="foreground_service_gmscompat_group">Compatibility</string>
+
+    <!-- Name for foreground service notification channel created by GmsCompat  -->
+    <string name="foreground_service_gmscompat_channel">Services</string>
+
+    <!-- Description for foreground service notification channel created by GmsCompat  -->
+    <string name="foreground_service_gmscompat_description">These notifications are created by the
+        Google Play Services compatibility layer in order to keep services running in the
+        background.\n\nDisable this category to hide the unnecessary notifications.</string>
 
     <!-- Displayed to the user to tell them that they have started up the phone in "safe mode" -->
     <string name="safeMode">Safe mode</string>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -3457,7 +3457,10 @@
   <java-symbol type="string" name="foreground_service_apps_in_background" />
   <java-symbol type="string" name="foreground_service_tap_for_details" />
   <java-symbol type="string" name="foreground_service_multiple_separator" />
-  <java-symbol type="string" name="foreground_service_gms_shim_category" />
+
+  <java-symbol type="string" name="foreground_service_gmscompat_group" />
+  <java-symbol type="string" name="foreground_service_gmscompat_channel" />
+  <java-symbol type="string" name="foreground_service_gmscompat_description" />
 
   <java-symbol type="bool" name="config_enableCredentialFactoryResetProtection" />
 

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -3460,7 +3460,8 @@
 
   <java-symbol type="string" name="foreground_service_gmscompat_group" />
   <java-symbol type="string" name="foreground_service_gmscompat_channel" />
-  <java-symbol type="string" name="foreground_service_gmscompat_description" />
+  <java-symbol type="string" name="foreground_service_gmscompat_channel_desc" />
+  <java-symbol type="string" name="foreground_service_gmscompat_notif_desc" />
 
   <java-symbol type="bool" name="config_enableCredentialFactoryResetProtection" />
 


### PR DESCRIPTION
- Add channel description and dedicated group
- Disable notification dots by default
- Description = "Tap to hide" to make it obvious that these notifications are unnecessary and can be disabled
- Open notification channel settings on tap to simplify disabling
- Clarify what the notification is for with "%s is running" (`app_running_notification_title`)