### PR TITLE
gmscompat: Add support for running GMS in secondary users

### DIFF
--- a/core/java/android/app/ContextImpl.java
+++ b/core/java/android/app/ContextImpl.java
@@ -1286,6 +1286,8 @@ class ContextImpl extends Context {
 
     @Override
     public void sendBroadcastAsUser(Intent intent, UserHandle user) {
+        user = GmsHooks.getUserHandle(user);
+
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         try {
             intent.prepareToLeaveProcess(this);
@@ -1307,6 +1309,8 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcastAsUser(Intent intent, UserHandle user, String receiverPermission,
             Bundle options) {
+        user = GmsHooks.getUserHandle(user);
+
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         String[] receiverPermissions = receiverPermission == null ? null
                 : new String[] {receiverPermission};
@@ -1324,6 +1328,8 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcastAsUser(Intent intent, UserHandle user,
             String receiverPermission, int appOp) {
+        user = GmsHooks.getUserHandle(user);
+
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         String[] receiverPermissions = receiverPermission == null ? null
                 : new String[] {receiverPermission};
@@ -1358,6 +1364,8 @@ class ContextImpl extends Context {
     public void sendOrderedBroadcastAsUser(Intent intent, UserHandle user,
             String receiverPermission, int appOp, Bundle options, BroadcastReceiver resultReceiver,
             Handler scheduler, int initialCode, String initialData, Bundle initialExtras) {
+        user = GmsHooks.getUserHandle(user);
+
         IIntentReceiver rd = null;
         if (resultReceiver != null) {
             if (mPackageInfo != null) {

--- a/core/java/android/app/compat/gms/GmsCompat.java
+++ b/core/java/android/app/compat/gms/GmsCompat.java
@@ -51,7 +51,7 @@ import com.android.internal.gmscompat.GmsInfo;
  */
 @SystemApi(client = SystemApi.Client.MODULE_LIBRARIES)
 public final class GmsCompat {
-    private static final String TAG = "GmsCompat";
+    private static final String TAG = "GmsCompat/Core";
 
     /**
      * Whether to enable Google Play Services compatibility for this app.

--- a/core/java/android/os/UserManager.java
+++ b/core/java/android/os/UserManager.java
@@ -1837,6 +1837,11 @@ public class UserManager {
      * @return whether this process is running under the system user.
      */
     public boolean isSystemUser() {
+        if (GmsCompat.isEnabled()) {
+            // com.android.vending: java.lang.IllegalStateException: This method must be called in primary profile
+            return true;
+        }
+
         return UserHandle.myUserId() == UserHandle.USER_SYSTEM;
     }
 
@@ -4175,6 +4180,11 @@ public class UserManager {
      */
     @UnsupportedAppUsage
     public int getUserSerialNumber(@UserIdInt int userId) {
+        if (GmsCompat.isEnabled()) {
+            // com.google.android.gms.persistent: java.lang.IllegalStateException - com.google.android.gms.gcm.GcmProxyIntentOperation.b
+            return 0;
+        }
+
         try {
             return mService.getUserSerialNumber(userId);
         } catch (RemoteException re) {

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -33,6 +33,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.SharedLibraryInfo;
 import android.os.Build;
 import android.os.Process;
+import android.os.UserHandle;
 import android.os.UserManager;
 import android.provider.Settings;
 import android.util.Log;
@@ -222,5 +223,12 @@ public final class GmsHooks {
 
         // Don't dispatch it, otherwise Play Store abandons the session
         return true;
+    }
+
+    // Redirect cross-user interactions to current user
+    // ContextImpl#sendOrderedBroadcastAsUser
+    // ContextImpl#sendBroadcastAsUser
+    public static UserHandle getUserHandle(UserHandle user) {
+        return GmsCompat.isEnabled() ? Process.myUserHandle() : user;
     }
 }

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -49,7 +49,7 @@ import java.util.List;
  * @hide
  */
 public final class GmsHooks {
-    private static final String TAG = "GmsHooks";
+    private static final String TAG = "GmsCompat/Hooks";
 
     // Foreground service notifications
     private static final String FGS_CHANNEL_ID = "service_shim";

--- a/telephony/java/android/telephony/TelephonyManager.java
+++ b/telephony/java/android/telephony/TelephonyManager.java
@@ -4519,6 +4519,14 @@ public class TelephonyManager {
                          mContext.getAttributionTag());
         } catch (RemoteException ex) {
         } catch (NullPointerException ex) {
+        } catch (SecurityException ex) {
+            if (GmsCompat.isEnabled()) {
+                // Google Play Services settings -> Account services -> Google Pay -> Add a payment method
+                // com.google.android.gms: java.lang.SecurityException: getLine1NumberForDisplay: Neither user 1010142 nor current process has android.permission.READ_PHONE_STATE, android.permission.READ_SMS, or android.permission.READ_PHONE_NUMBERS
+                return null;
+            } else {
+                throw ex;
+            }
         }
         if (number != null) {
             return number;


### PR DESCRIPTION
Tested functionality:
  - Account login (including 2FA with NFC security key)
  - Play Store
  - Firebase Cloud Messaging (Signal, Discord)
  - Firebase database API (Swift Backup)
  - Firebase app indexing (GMS debug settings)
  - Google Play Games
  - Account settings
  - Google My Account
  - SMS verification receiver (Signal)
  - Play license verification (both in-app purchases and paid apps)