### PR TITLE
gmscompat: Fix crashes in secondary users

### DIFF
--- a/core/java/android/app/compat/gms/GmsCompat.java
+++ b/core/java/android/app/compat/gms/GmsCompat.java
@@ -108,8 +108,9 @@ public final class GmsCompat {
         boolean enabled = Compatibility.isChangeEnabled(changeId);
 
         // Compatibility changes aren't available in the system process, but this should never be
-        // enabled for it.
-        if (Process.myUid() == Process.SYSTEM_UID) {
+        // enabled for it or other core "android" system processes (such as the android:ui process
+        // used for chooser and resolver activities).
+        if (UserHandle.getAppId(Process.myUid()) == Process.SYSTEM_UID) {
             enabled = false;
         }
 

--- a/core/java/com/android/internal/gmscompat/dynamite/client/DynamiteContext.java
+++ b/core/java/com/android/internal/gmscompat/dynamite/client/DynamiteContext.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.os.Environment;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
@@ -30,6 +31,8 @@ import android.util.Log;
 import com.android.internal.gmscompat.GmsInfo;
 import com.android.internal.gmscompat.dynamite.server.FileProxyProvider;
 import com.android.internal.gmscompat.dynamite.server.IFileProxyService;
+
+import java.io.File;
 
 /** @hide */
 public final class DynamiteContext {
@@ -53,10 +56,10 @@ public final class DynamiteContext {
     public DynamiteContext(Context context) {
         this.context = context;
 
-        // Use our own context and replace the package name to avoid ApkAssets recursion when
-        // lazy-creating a DynamiteContext in the ApkAssets hook
-        this.gmsDataPrefix = context.createDeviceProtectedStorageContext().getDataDir().getPath()
-                .replace(context.getPackageName(), GmsInfo.PACKAGE_GMS) + "/";
+        // Get data directory path without using package context or current data dir, since not all
+        // packages have data directories and package context causes recursion in ApkAssets
+        File userDe = Environment.getDataUserDeDirectory(null, context.getUserId());
+        gmsDataPrefix = userDe.getPath() + '/' + GmsInfo.PACKAGE_GMS + '/';
     }
 
     public ModuleLoadState getState() {


### PR DESCRIPTION
The chooser and resolver activities run as a special system UI process belonging to the core `android` package, separate from both system_server and com.android.systemui. This process, named `android:ui`, runs separately under each user with the special app ID 1000 (SYSTEM_UID).

Check the app ID instead of the UID to fix detection of SYSTEM_UID processes in secondary users.

This fixes the following crash and adds a failsafe for potentially related issues in the future:

```
FATAL EXCEPTION: AsyncTask #2
Process: system:ui, PID: 8982
java.lang.RuntimeException: An error occurred while executing doInBackground()
	at android.os.AsyncTask$4.done(AsyncTask.java:415)
	at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
	at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
	at java.util.concurrent.FutureTask.run(FutureTask.java:271)
	at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:305)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:923)
Caused by: java.lang.RuntimeException: No data directory found for package android
	at android.app.ContextImpl.getDataDir(ContextImpl.java:2560)
	at com.android.internal.gmscompat.dynamite.client.DynamiteContext.<init>(DynamiteContext.java:58)
	at com.android.internal.gmscompat.dynamite.GmsDynamiteHooks.getClientContext(GmsDynamiteHooks.java:64)
	at com.android.internal.gmscompat.dynamite.GmsDynamiteHooks.loadAssetsFromPath(GmsDynamiteHooks.java:93)
	at android.content.res.ApkAssets.loadFromPath(ApkAssets.java:143)
	at android.app.ResourcesManager.loadApkAssets(ResourcesManager.java:374)
	at android.app.ResourcesManager.access$000(ResourcesManager.java:67)
	at android.app.ResourcesManager$ApkAssetsSupplier.load(ResourcesManager.java:146)
	at android.app.ResourcesManager.createApkAssetsSupplierNotLocked(ResourcesManager.java:833)
	at android.app.ResourcesManager.getResources(ResourcesManager.java:937)
	at android.app.ActivityThread.getTopLevelResources(ActivityThread.java:2226)
	at android.app.ApplicationPackageManager.getResourcesForApplication(ApplicationPackageManager.java:1682)
	at com.android.internal.app.ResolverListAdapter$TargetPresentationGetter.getIconBitmap(ResolverListAdapter.java:920)
	at com.android.internal.app.ResolverListAdapter$ActivityInfoPresentationGetter.getIconBitmap(ResolverListAdapter.java:843)
	at com.android.internal.app.ResolverListAdapter$TargetPresentationGetter.getIcon(ResolverListAdapter.java:908)
	at com.android.internal.app.ResolverListAdapter$ActivityInfoPresentationGetter.getIcon(ResolverListAdapter.java:843)
	at com.android.internal.app.ResolverListAdapter.loadIconForResolveInfo(ResolverListAdapter.java:599)
	at com.android.internal.app.ResolverListAdapter$LoadIconTask.doInBackground(ResolverListAdapter.java:782)
	at com.android.internal.app.ResolverListAdapter$LoadIconTask.doInBackground(ResolverListAdapter.java:769)
	at android.os.AsyncTask$3.call(AsyncTask.java:394)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	... 4 more
```

Fixes https://github.com/GrapheneOS/os-issue-tracker/issues/618.