### PR TITLE
gmscompat: Fix missing force queryable flag for GSF

### DIFF
--- a/services/core/java/com/android/server/pm/AppsFilter.java
+++ b/services/core/java/com/android/server/pm/AppsFilter.java
@@ -565,13 +565,16 @@ public class AppsFilter {
             mQueriesViaComponentRequireRecompute = true;
         }
 
+        final boolean isGmsApp = GmsCompat.isGmsApp(newPkg.getPackageName(),
+                newPkg.getSigningDetails().signatures,
+                newPkg.getSigningDetails().pastSigningCertificates,
+                newPkg.isPrivileged(),
+                newPkgSetting.sharedUser != null ? newPkgSetting.sharedUser.name : null);
         final boolean newIsForceQueryable =
                 mForceQueryable.contains(newPkgSetting.appId)
                         /* shared user that is already force queryable */
                         || newPkgSetting.forceQueryableOverride /* adb override */
-                        || GmsCompat.isGmsApp(newPkg.getPackageName(),
-                            newPkg.getSigningDetails().signatures, newPkg.isPrivileged(),
-                            newPkgSetting.sharedUser != null ? newPkgSetting.sharedUser.name : null)
+                        || isGmsApp
                         || (newPkgSetting.isSystem() && (mSystemAppsQueryable
                         || newPkg.isForceQueryable()
                         || ArrayUtils.contains(mForceQueryableByDevicePackageNames,


### PR DESCRIPTION
The force queryable check in AppsFilter calls isGmsApp with the *current* APK signatures, which works for some Google apps. However, Google Services Framework (`com.google.android.gsf`) has a v3 signature that uses a new certificate, so the legacy MD5 certificate we check for is classified as a past signing certificate instead. As a result, forceQueryable is never set for GSF because it fails the isGmsApp check.

Account for both current and past signing certificates in the AppsFilter path in order to fix the issue.

Fixes https://github.com/GrapheneOS/os-issue-tracker/issues/621.