### PR TITLE
gmscompat: Handle all exact alarm denials

### DIFF
--- a/apex/jobscheduler/framework/java/android/app/AlarmManager.java
+++ b/apex/jobscheduler/framework/java/android/app/AlarmManager.java
@@ -913,6 +913,11 @@ public class AlarmManager {
             long intervalMillis, int flags, PendingIntent operation, final OnAlarmListener listener,
             String listenerTag, Executor targetExecutor, WorkSource workSource,
             AlarmClockInfo alarmClock) {
+        if (GmsCompat.isEnabled() && windowMillis == WINDOW_EXACT &&
+                !canScheduleExactAlarms()) {
+            windowMillis = WINDOW_HEURISTIC;
+        }
+
         if (triggerAtMillis < 0) {
             /* NOTYET
             if (mAlwaysExact) {
@@ -1173,11 +1178,6 @@ public class AlarmManager {
     @RequiresPermission(value = Manifest.permission.SCHEDULE_EXACT_ALARM, conditional = true)
     public void setExactAndAllowWhileIdle(@AlarmType int type, long triggerAtMillis,
             PendingIntent operation) {
-        if (GmsCompat.isEnabled() && !canScheduleExactAlarms()) {
-            setAndAllowWhileIdle(type, triggerAtMillis, operation);
-            return;
-        }
-
         setImpl(type, triggerAtMillis, WINDOW_EXACT, 0, FLAG_ALLOW_WHILE_IDLE, operation,
                 null, null, (Handler) null, null, null);
     }


### PR DESCRIPTION
```
java.lang.SecurityException: Caller com.google.android.gms needs to hold android.permission.SCHEDULE_EXACT_ALARM to set exact alarms.
	at android.os.Parcel.createExceptionOrNull(Parcel.java:2425)
	at android.os.Parcel.createException(Parcel.java:2409)
	at android.os.Parcel.readException(Parcel.java:2392)
	at android.os.Parcel.readException(Parcel.java:2334)
	at android.app.IAlarmManager$Stub$Proxy.set(IAlarmManager.java:359)
	at android.app.AlarmManager.setImpl(AlarmManager.java:948)
	at android.app.AlarmManager.setImpl(AlarmManager.java:908)
	at android.app.AlarmManager.set(AlarmManager.java:818)
	at usv.k(:com.google.android.gms@213314046@21.33.14 (150400-395723304):1)
	at usv.o(:com.google.android.gms@213314046@21.33.14 (150400-395723304):0)
	at usv.e(:com.google.android.gms@213314046@21.33.14 (150400-395723304):2)
	at com.google.android.contextmanager.controller.EventHandler$AlarmSetter.c(:com.google.android.gms@213314046@21.33.14 (150400-395723304):8)
	at exr.d(:com.google.android.gms@213314046@21.33.14 (150400-395723304):3)
	at ext.l(:com.google.android.gms@213314046@21.33.14 (150400-395723304):0)
	at evr.a(:com.google.android.gms@213314046@21.33.14 (150400-395723304):143)
	at ext.run(:com.google.android.gms@213314046@21.33.14 (150400-395723304):2)
	at exp.handleMessage(:com.google.android.gms@213314046@21.33.14 (150400-395723304):3)
	at uwe.run(:com.google.android.gms@213314046@21.33.14 (150400-395723304):2)
	at uwo.c(:com.google.android.gms@213314046@21.33.14 (150400-395723304):6)
	at uwo.run(:com.google.android.gms@213314046@21.33.14 (150400-395723304):8)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at vcm.run(:com.google.android.gms@213314046@21.33.14 (150400-395723304):0)
	at java.lang.Thread.run(Thread.java:920)
```