### PR TITLE
colors: Switch to GrapheneOS blue color palette for Material You

### DIFF
--- a/core/res/res/values/colors.xml
+++ b/core/res/res/values/colors.xml
@@ -248,37 +248,37 @@
     <color name="system_accent1_0">#ffffff</color>
     <!-- Shade of the accent system color at 99% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent1_10">#F9FCFF</color>
+    <color name="system_accent1_10">#fafcff</color>
     <!-- Shade of the accent system color at 95% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent1_50">#E0F3FF</color>
+    <color name="system_accent1_50">#e5f1ff</color>
     <!-- Shade of the accent system color at 90% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent1_100">#C1E8FF</color>
+    <color name="system_accent1_100">#cbe2ff</color>
     <!-- Shade of the accent system color at 80% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent1_200">#76D1FF</color>
+    <color name="system_accent1_200">#95c4ff</color>
     <!-- Shade of the accent system color at 70% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent1_300">#4BB6E8</color>
+    <color name="system_accent1_300">#5ba2ff</color>
     <!-- Shade of the accent system color at 60% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent1_400">#219BCC</color>
+    <color name="system_accent1_400">#3884e7</color>
     <!-- Shade of the accent system color at 49% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent1_500">#007FAC</color>
+    <color name="system_accent1_500">#1b69c5</color>
     <!-- Shade of the accent system color at 40% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent1_600">#00668B</color>
+    <color name="system_accent1_600">#0053a3</color>
     <!-- Shade of the accent system color at 30% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent1_700">#004C69</color>
+    <color name="system_accent1_700">#003f7b</color>
     <!-- Shade of the accent system color at 20% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent1_800">#003549</color>
+    <color name="system_accent1_800">#002b55</color>
     <!-- Shade of the accent system color at 10% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent1_900">#001E2C</color>
+    <color name="system_accent1_900">#001933</color>
     <!-- Darkest shade of the accent color used by the system. Black.
      This value can be overlaid at runtime by OverlayManager RROs. -->
     <color name="system_accent1_1000">#000000</color>
@@ -288,37 +288,37 @@
     <color name="system_accent2_0">#ffffff</color>
     <!-- Shade of the secondary accent system color at 99% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent2_10">#F9FCFF</color>
+    <color name="system_accent2_10">#fafcff</color>
     <!-- Shade of the secondary accent system color at 95% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent2_50">#E0F3FF</color>
+    <color name="system_accent2_50">#e5f1ff</color>
     <!-- Shade of the secondary accent system color at 90% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent2_100">#D1E5F4</color>
+    <color name="system_accent2_100">#cee2fb</color>
     <!-- Shade of the secondary accent system color at 80% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent2_200">#B5CAD7</color>
+    <color name="system_accent2_200">#b4c6dd</color>
     <!-- Shade of the secondary accent system color at 70% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent2_300">#9AAEBB</color>
+    <color name="system_accent2_300">#9aabc0</color>
     <!-- Shade of the secondary accent system color at 60% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent2_400">#8094A0</color>
+    <color name="system_accent2_400">#8090a4</color>
     <!-- Shade of the secondary accent system color at 49% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent2_500">#657985</color>
+    <color name="system_accent2_500">#677688</color>
     <!-- Shade of the secondary accent system color at 40% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent2_600">#4E616C</color>
+    <color name="system_accent2_600">#505e6f</color>
     <!-- Shade of the secondary accent system color at 30% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent2_700">#374955</color>
+    <color name="system_accent2_700">#394656</color>
     <!-- Shade of the secondary accent system color at 20% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent2_800">#20333D</color>
+    <color name="system_accent2_800">#23303f</color>
     <!-- Shade of the secondary accent system color at 10% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent2_900">#091E28</color>
+    <color name="system_accent2_900">#0d1b29</color>
     <!-- Darkest shade of the secondary accent color used by the system. Black.
      This value can be overlaid at runtime by OverlayManager RROs. -->
     <color name="system_accent2_1000">#000000</color>
@@ -328,37 +328,37 @@
     <color name="system_accent3_0">#ffffff</color>
     <!-- Shade of the tertiary accent system color at 99% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent3_10">#FFFBFF</color>
+    <color name="system_accent3_10">#fffaff</color>
     <!-- Shade of the tertiary accent system color at 95% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent3_50">#F5EEFF</color>
+    <color name="system_accent3_50">#fce8ff</color>
     <!-- Shade of the tertiary accent system color at 90% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent3_100">#E6DEFF</color>
+    <color name="system_accent3_100">#f8d0ff</color>
     <!-- Shade of the tertiary accent system color at 80% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent3_200">#CAC1EA</color>
+    <color name="system_accent3_200">#eba3f8</color>
     <!-- Shade of the tertiary accent system color at 70% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent3_300">#AEA6CE</color>
+    <color name="system_accent3_300">#ce8ad9</color>
     <!-- Shade of the tertiary accent system color at 60% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent3_400">#938CB1</color>
+    <color name="system_accent3_400">#b071bb</color>
     <!-- Shade of the tertiary accent system color at 49% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent3_500">#787296</color>
+    <color name="system_accent3_500">#93589d</color>
     <!-- Shade of the tertiary accent system color at 40% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent3_600">#605A7C</color>
+    <color name="system_accent3_600">#794183</color>
     <!-- Shade of the tertiary accent system color at 30% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent3_700">#484264</color>
+    <color name="system_accent3_700">#5f2968</color>
     <!-- Shade of the tertiary accent system color at 20% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent3_800">#322C4C</color>
+    <color name="system_accent3_800">#470e4f</color>
     <!-- Shade of the tertiary accent system color at 10% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_accent3_900">#1D1736</color>
+    <color name="system_accent3_900">#2d0033</color>
     <!-- Darkest shade of the tertiary accent color used by the system. Black.
      This value can be overlaid at runtime by OverlayManager RROs. -->
     <color name="system_accent3_1000">#000000</color>
@@ -368,37 +368,37 @@
     <color name="system_neutral1_0">#ffffff</color>
     <!-- Shade of the neutral system color at 99% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral1_10">#FCFCFF</color>
+    <color name="system_neutral1_10">#fafcff</color>
     <!-- Shade of the neutral system color at 95% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral1_50">#F0F0F3</color>
+    <color name="system_neutral1_50">#ebf1f7</color>
     <!-- Shade of the neutral system color at 90% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral1_100">#E1E3E5</color>
+    <color name="system_neutral1_100">#dde2e9</color>
     <!-- Shade of the neutral system color at 80% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral1_200">#C5C7C9</color>
+    <color name="system_neutral1_200">#c2c6cc</color>
     <!-- Shade of the neutral system color at 70% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral1_300">#AAABAE</color>
+    <color name="system_neutral1_300">#a7abb1</color>
     <!-- Shade of the neutral system color at 60% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral1_400">#8F9193</color>
+    <color name="system_neutral1_400">#8c9196</color>
     <!-- Shade of the neutral system color at 49% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral1_500">#747679</color>
+    <color name="system_neutral1_500">#72767b</color>
     <!-- Shade of the neutral system color at 40% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral1_600">#5C5F61</color>
+    <color name="system_neutral1_600">#5b5e63</color>
     <!-- Shade of the neutral system color at 30% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral1_700">#454749</color>
+    <color name="system_neutral1_700">#43474b</color>
     <!-- Shade of the neutral system color at 20% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral1_800">#2E3133</color>
+    <color name="system_neutral1_800">#2d3034</color>
     <!-- Shade of the neutral system color at 10% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral1_900">#191C1E</color>
+    <color name="system_neutral1_900">#181c1f</color>
     <!-- Darkest shade of the neutral color used by the system. Black.
      This value can be overlaid at runtime by OverlayManager RROs. -->
     <color name="system_neutral1_1000">#000000</color>
@@ -408,37 +408,37 @@
     <color name="system_neutral2_0">#ffffff</color>
     <!-- Shade of the secondary neutral system color at 99% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral2_10">#F9FCFF</color>
+    <color name="system_neutral2_10">#fafcff</color>
     <!-- Shade of the secondary neutral system color at 95% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral2_50">#EBF1F8</color>
+    <color name="system_neutral2_50">#e6f1fd</color>
     <!-- Shade of the secondary neutral system color at 90% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral2_100">#DCE3E9</color>
+    <color name="system_neutral2_100">#d9e2ef</color>
     <!-- Shade of the secondary neutral system color at 80% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral2_200">#C0C7CD</color>
+    <color name="system_neutral2_200">#bdc6d2</color>
     <!-- Shade of the secondary neutral system color at 70% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral2_300">#A5ACB2</color>
+    <color name="system_neutral2_300">#a2abb6</color>
     <!-- Shade of the secondary neutral system color at 60% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral2_400">#8A9297</color>
+    <color name="system_neutral2_400">#88919a</color>
     <!-- Shade of the secondary neutral system color at 49% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral2_500">#70777C</color>
+    <color name="system_neutral2_500">#6e767f</color>
     <!-- Shade of the secondary neutral system color at 40% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral2_600">#585F65</color>
+    <color name="system_neutral2_600">#575e67</color>
     <!-- Shade of the secondary neutral system color at 30% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral2_700">#40484D</color>
+    <color name="system_neutral2_700">#40474f</color>
     <!-- Shade of the secondary neutral system color at 20% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral2_800">#2A3136</color>
+    <color name="system_neutral2_800">#2a3038</color>
     <!-- Shade of the secondary neutral system color at 10% lightness.
      This value can be overlaid at runtime by OverlayManager RROs. -->
-    <color name="system_neutral2_900">#161C20</color>
+    <color name="system_neutral2_900">#151b23</color>
     <!-- Darkest shade of the secondary neutral color used by the system. Black.
      This value can be overlaid at runtime by OverlayManager RROs. -->
     <color name="system_neutral2_1000">#000000</color>


### PR DESCRIPTION
Generated with [Android 12 Extensions](https://github.com/kdrag0n/android12-extensions/) v9.0.0-test2 using #1565C0 (light link accent color from GrapheneOS website) as a seed color, with all other settings left at [themelib](https://github.com/ProtonAOSP/android_external_themelib) and [colorkt](https://github.com/kdrag0n/colorkt) defaults.