### PR TITLE
gmscompat: improve Play Store compatibility

### DIFF
--- a/core/java/android/app/ApplicationPackageManager.java
+++ b/core/java/android/app/ApplicationPackageManager.java
@@ -122,6 +122,7 @@ import com.android.internal.annotations.GuardedBy;
 import com.android.internal.annotations.Immutable;
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.internal.gmscompat.GmsHooks;
+import com.android.internal.gmscompat.PlayStoreHooks;
 import com.android.internal.os.SomeArgs;
 import com.android.internal.util.UserIcons;
 
@@ -2513,6 +2514,10 @@ public class ApplicationPackageManager extends PackageManager {
     @Override
     @UnsupportedAppUsage
     public void deletePackage(String packageName, IPackageDeleteObserver observer, int flags) {
+        if (GmsCompat.isPlayStore()) {
+            PlayStoreHooks.deletePackage(mContext, this, packageName, observer, flags);
+            return;
+        }
         deletePackageAsUser(packageName, observer, flags, getUserId());
     }
 

--- a/core/java/android/app/LoadedApk.java
+++ b/core/java/android/app/LoadedApk.java
@@ -1573,10 +1573,6 @@ public final class LoadedApk {
             @Override
             public void performReceive(Intent intent, int resultCode, String data,
                     Bundle extras, boolean ordered, boolean sticky, int sendingUser) {
-                if (GmsHooks.performReceive(intent)) {
-                    return;
-                }
-
                 final LoadedApk.ReceiverDispatcher rd;
                 if (intent == null) {
                     Log.wtf(TAG, "Null intent received");

--- a/core/java/android/content/pm/PackageInstaller.java
+++ b/core/java/android/content/pm/PackageInstaller.java
@@ -32,6 +32,7 @@ import android.annotation.SystemApi;
 import android.annotation.TestApi;
 import android.app.ActivityManager;
 import android.app.AppGlobals;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.Intent;
 import android.content.IntentSender;
@@ -57,6 +58,7 @@ import android.text.TextUtils;
 import android.util.ArraySet;
 import android.util.ExceptionUtils;
 
+import com.android.internal.gmscompat.PlayStoreHooks;
 import com.android.internal.util.IndentingPrintWriter;
 import com.android.internal.util.Preconditions;
 import com.android.internal.util.function.pooled.PooledLambda;
@@ -690,6 +692,9 @@ public class PackageInstaller {
     public void uninstall(@NonNull VersionedPackage versionedPackage, @DeleteFlags int flags,
             @NonNull IntentSender statusReceiver) {
         Objects.requireNonNull(versionedPackage, "versionedPackage cannot be null");
+        if (GmsCompat.isPlayStore()) {
+            statusReceiver = PlayStoreHooks.wrapPackageInstallerStatusReceiver(statusReceiver);
+        }
         try {
             mInstaller.uninstall(versionedPackage, mInstallerPackageName,
                     flags, statusReceiver, mUserId);
@@ -1309,6 +1314,9 @@ public class PackageInstaller {
          * @see android.app.admin.DevicePolicyManager
          */
         public void commit(@NonNull IntentSender statusReceiver) {
+            if (GmsCompat.isPlayStore()) {
+                statusReceiver = PlayStoreHooks.wrapPackageInstallerStatusReceiver(statusReceiver);
+            }
             try {
                 mSession.commit(statusReceiver, false);
             } catch (RemoteException e) {
@@ -1631,6 +1639,10 @@ public class PackageInstaller {
          */
         public SessionParams(int mode) {
             this.mode = mode;
+            if (GmsCompat.isPlayStore()) {
+                // called here instead of in createSession() to give Play Store a chance to override
+                setRequireUserAction(USER_ACTION_NOT_REQUIRED);
+            }
         }
 
         /** {@hide} */

--- a/core/java/android/content/pm/PackageParser.java
+++ b/core/java/android/content/pm/PackageParser.java
@@ -290,6 +290,10 @@ public class PackageParser {
         new PackageParser.NewPermissionInfo[] {
             new PackageParser.NewPermissionInfo(android.Manifest.permission.REQUEST_INSTALL_PACKAGES,
                     android.os.Build.VERSION_CODES.CUR_DEVELOPMENT + 1, 0, GmsInfo.PACKAGE_PLAY_STORE),
+            new PackageParser.NewPermissionInfo(android.Manifest.permission.REQUEST_DELETE_PACKAGES,
+                    android.os.Build.VERSION_CODES.CUR_DEVELOPMENT + 1, 0, GmsInfo.PACKAGE_PLAY_STORE),
+            new PackageParser.NewPermissionInfo(android.Manifest.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION,
+                    android.os.Build.VERSION_CODES.CUR_DEVELOPMENT + 1, 0, GmsInfo.PACKAGE_PLAY_STORE),
             new PackageParser.NewPermissionInfo(android.Manifest.permission.OTHER_SENSORS,
                     android.os.Build.VERSION_CODES.CUR_DEVELOPMENT + 1, 0),
             new PackageParser.NewPermissionInfo(android.Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/core/java/com/android/internal/gmscompat/PlayStoreHooks.java
+++ b/core/java/com/android/internal/gmscompat/PlayStoreHooks.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat;
+
+import android.app.ActivityManager;
+import android.app.ActivityThread;
+import android.app.IActivityManager;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.IntentSender;
+import android.content.pm.IPackageDeleteObserver;
+import android.content.pm.PackageInstaller;
+import android.content.pm.PackageManager;
+import android.os.Process;
+import android.os.RemoteException;
+
+import com.android.internal.R;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
+
+public final class PlayStoreHooks {
+
+    private static final String TAG = "GmsCompat/PlayStore";
+
+    // Pending user action notifications
+    static final String PUA_CHANNEL_ID = "gmscompat_playstore_pua_channel";
+    private static final int PUA_NOTIFICATION_ID = 429825706;
+
+    private PlayStoreHooks() {}
+
+    static void createNotificationChannel(Context context, ArrayList<NotificationChannel> dest) {
+        CharSequence name = context.getText(R.string.gmscompat_notif_channel_action_required);
+        NotificationChannel c = new NotificationChannel(PUA_CHANNEL_ID, name,
+                NotificationManager.IMPORTANCE_LOW);
+        c.setShowBadge(false);
+
+        dest.add(c);
+    }
+
+    // Play Store doesn't handle PENDING_USER_ACTION status from PackageInstaller
+    // PackageInstaller.Session#commit(IntentSender)
+    // PackageInstaller#uninstall(VersionedPackage, int, IntentSender)
+    public static IntentSender wrapPackageInstallerStatusReceiver(IntentSender statusReceiver) {
+        Context context = ActivityThread.currentApplication();
+        Objects.requireNonNull(context);
+        return PackageInstallerStatusForwarder.wrap(context, statusReceiver).getIntentSender();
+    }
+
+    static class PackageInstallerStatusForwarder extends BroadcastReceiver {
+        private Context context;
+        private IntentSender target;
+
+        private static final AtomicLong lastId = new AtomicLong();
+
+        static PendingIntent wrap(Context context, IntentSender target) {
+            PackageInstallerStatusForwarder sf = new PackageInstallerStatusForwarder();
+            sf.context = context;
+            sf.target = target;
+
+            String intentAction = context.getPackageName()
+                + "." + PackageInstallerStatusForwarder.class.getName() + "."
+                + lastId.getAndIncrement();
+            context.registerReceiver(sf, new IntentFilter(intentAction));
+
+            return PendingIntent.getBroadcast(context, 0, new Intent(intentAction),
+                    PendingIntent.FLAG_CANCEL_CURRENT |
+                        PendingIntent.FLAG_MUTABLE);
+        }
+
+        public void onReceive(Context br_context, Intent intent) {
+            String statusKey = PackageInstaller.EXTRA_STATUS;
+            if (! intent.hasExtra(statusKey)) {
+                throw new IllegalStateException("no EXTRA_STATUS in intent " + intent);
+            }
+            int status = intent.getIntExtra(statusKey, 0);
+
+            if (status == PackageInstaller.STATUS_PENDING_USER_ACTION) {
+                Intent confirmationIntent = intent.getParcelableExtra(Intent.EXTRA_INTENT);
+                confirmationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+                boolean foreground = isForeground(Process.myUid(), Process.myPid());
+
+                if (foreground) {
+                    context.startActivity(confirmationIntent);
+                } else {
+                    // allow multiple PUA notifications
+                    int id = PUA_NOTIFICATION_ID + (((int) lastId.get()) & 0xffff);
+
+                    PendingIntent pi = PendingIntent.getActivity(context, id, confirmationIntent,
+                        PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_CANCEL_CURRENT);
+
+                    Notification notification =
+                        GmsHooks.obtainNotificationBuilder(context, PUA_CHANNEL_ID)
+                        // TODO better icon
+                        .setSmallIcon(context.getApplicationInfo().icon)
+                        .setContentTitle(context.getText(R.string.gmscompat_notif_channel_action_required))
+                        .setContentIntent(pi)
+                        .setAutoCancel(true)
+                        .build();
+
+                    NotificationManager nm = context.getSystemService(NotificationManager.class);
+                    nm.notify(id, notification);
+                }
+                // confirmationIntent has a PendingIntent to this instance, don't unregister yet
+                return;
+            }
+
+            context.unregisterReceiver(this);
+
+            try {
+                target.sendIntent(context, 0, intent, null, null);
+            } catch (IntentSender.SendIntentException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    static boolean isForeground(int uid, int pid) {
+        final List<ActivityManager.RunningAppProcessInfo> procs;
+        try {
+            // returns only processes that belong to the current app
+            procs = ActivityManager.getService().getRunningAppProcesses();
+            Objects.requireNonNull(procs);
+        } catch (RemoteException e) {
+            throw e.rethrowAsRuntimeException();
+        }
+        for (int i = 0; i < procs.size(); i++) {
+            ActivityManager.RunningAppProcessInfo proc = procs.get(i);
+            if (proc.pid == pid && proc.uid == uid
+                    && proc.importance == IMPORTANCE_FOREGROUND) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Request user action to uninstall a package
+    // ApplicationPackageManager#deletePackage(String, IPackageDeleteObserver, int)
+    public static void deletePackage(Context context, PackageManager pm, String packageName, IPackageDeleteObserver observer, int flags) {
+        if (flags != 0) {
+            throw new IllegalStateException("unexpected flags: " + flags);
+        }
+        PendingIntent pi = UninstallStatusForwarder.getPendingIntent(context, packageName, observer);
+        // will call PackageInstallerStatusForwarder,
+        // no need to handle confirmation in UninstallStatusForwarder
+        pm.getPackageInstaller().uninstall(packageName, pi.getIntentSender());
+    }
+
+    static class UninstallStatusForwarder extends BroadcastReceiver {
+        private Context context;
+        private String packageName;
+        private IPackageDeleteObserver target;
+
+        private static final AtomicLong lastId = new AtomicLong();
+
+        static PendingIntent getPendingIntent(Context context, String packageName, IPackageDeleteObserver target) {
+            UninstallStatusForwarder sf = new UninstallStatusForwarder();
+            sf.context = context;
+            sf.packageName = packageName;
+            sf.target = target;
+
+            String intentAction = context.getPackageName()
+                + "." + UninstallStatusForwarder.class.getName() + "."
+                + lastId.getAndIncrement();
+
+            context.registerReceiver(sf, new IntentFilter(intentAction));
+
+            return PendingIntent.getBroadcast(context, 0, new Intent(intentAction),
+                    PendingIntent.FLAG_CANCEL_CURRENT |
+                        PendingIntent.FLAG_ONE_SHOT |
+                        PendingIntent.FLAG_MUTABLE);
+        }
+
+        public void onReceive(Context br_context, Intent intent) {
+            context.unregisterReceiver(this);
+
+            // EXTRA_STATUS returns PackageInstaller constant,
+            // EXTRA_LEGACY_STATUS returns PackageManager constant
+            String statusKey = PackageInstaller.EXTRA_LEGACY_STATUS;
+            if (!intent.hasExtra(statusKey)) {
+                throw new IllegalStateException("no EXTRA_LEGACY_STATUS in intent " + intent);
+            }
+
+            int status = intent.getIntExtra(statusKey, 0);
+            try {
+                target.packageDeleted(packageName, status);
+            } catch (RemoteException e) {
+                throw e.rethrowAsRuntimeException();
+            }
+        }
+    }
+}

--- a/core/res/res/values/strings.xml
+++ b/core/res/res/values/strings.xml
@@ -764,8 +764,8 @@
     <string name="foreground_service_multiple_separator"><xliff:g id="left_side">%1$s</xliff:g>,
         <xliff:g id="right_side">%2$s</xliff:g></string>
 
-    <!-- Name for foreground service notification channel group created by GmsCompat  -->
-    <string name="foreground_service_gmscompat_group">Compatibility</string>
+    <!-- Name for GmsCompat notification channel group -->
+    <string name="gmscompat_channel_group">Compatibility</string>
 
     <!-- Name for foreground service notification channel created by GmsCompat  -->
     <string name="foreground_service_gmscompat_channel">Services</string>
@@ -777,6 +777,8 @@
 
     <!-- Description for foreground service notifications created by GmsCompat  -->
     <string name="foreground_service_gmscompat_notif_desc">Tap to hide</string>
+
+    <string name="gmscompat_notif_channel_action_required">Action required</string>
 
     <!-- Displayed to the user to tell them that they have started up the phone in "safe mode" -->
     <string name="safeMode">Safe mode</string>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -3618,10 +3618,11 @@
   <java-symbol type="string" name="foreground_service_tap_for_details" />
   <java-symbol type="string" name="foreground_service_multiple_separator" />
 
-  <java-symbol type="string" name="foreground_service_gmscompat_group" />
+  <java-symbol type="string" name="gmscompat_channel_group" />
   <java-symbol type="string" name="foreground_service_gmscompat_channel" />
   <java-symbol type="string" name="foreground_service_gmscompat_channel_desc" />
   <java-symbol type="string" name="foreground_service_gmscompat_notif_desc" />
+  <java-symbol type="string" name="gmscompat_notif_channel_action_required" />
 
   <java-symbol type="bool" name="config_enableCredentialFactoryResetProtection" />
 


### PR DESCRIPTION
What works:
- package (un)installation confirmation
- unattended app upgrades (for apps that target API 29+)

What doesn't work:
- Play Store self-update. Should work once it starts to use the modern APIs.
- Play Store doesn't expect package uninstallation to fail, 
progress spinner continues indefinitely if confirmation is declined.

`UPDATE_PACKAGES_WITHOUT_USER_ACTION` and `REQUEST_DELETE_PACKAGES` permissions should be granted to Play Store during the OS upgrade. To grant them immediately, reinstall the Play Store app.