### PR TITLE
gmscompat: compatibility with Play Store self-update

### DIFF
--- a/core/java/android/app/ApplicationPackageManager.java
+++ b/core/java/android/app/ApplicationPackageManager.java
@@ -2564,6 +2564,10 @@ public class ApplicationPackageManager extends PackageManager {
     @Override
     public void freeStorageAndNotify(String volumeUuid, long idealStorageSize,
             IPackageDataObserver observer) {
+        if (GmsCompat.isPlayStore()) {
+            PlayStoreHooks.freeStorageAndNotify(mContext, volumeUuid, idealStorageSize, observer);
+            return;
+        }
         try {
             mPM.freeStorageAndNotify(volumeUuid, idealStorageSize, 0, observer);
         } catch (RemoteException e) {

--- a/core/java/android/content/ContentResolver.java
+++ b/core/java/android/content/ContentResolver.java
@@ -31,6 +31,7 @@ import android.app.ActivityManager;
 import android.app.ActivityThread;
 import android.app.AppGlobals;
 import android.app.UriGrantsManager;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
@@ -71,6 +72,7 @@ import android.util.Size;
 import android.util.SparseArray;
 
 import com.android.internal.annotations.GuardedBy;
+import com.android.internal.gmscompat.PlayStoreHooks;
 import com.android.internal.util.MimeIconUtils;
 
 import dalvik.system.CloseGuard;
@@ -2177,6 +2179,9 @@ public abstract class ContentResolver implements ContentInterface {
     public final @Nullable Uri insert(@RequiresPermission.Write @NonNull Uri url,
             @Nullable ContentValues values, @Nullable Bundle extras) {
         Objects.requireNonNull(url, "url");
+        if (GmsCompat.isPlayStore()) {
+            PlayStoreHooks.filterContentValues(url, values);
+        }
 
         try {
             if (mWrapped != null) return mWrapped.insert(url, values, extras);


### PR DESCRIPTION
Needs to be applied together with the [DownloadProvider patch](https://github.com/GrapheneOS/platform_packages_providers_DownloadProvider/pull/2).

Self-update fully works, seems unlikely to break with the future Play Store updates.

To test, install the outdated Play Store version and tap on the "Play Store version" list item in Play Store settings.
It should show the message that update download has started.
Then wait for `SU: Self-update ready to be installed, waiting for market to close.` logcat message,
press the home button, and after ~20 seconds self-update should start.