### PR TITLE
gmscompat: mark confirmation notification from Play Store as ongoing

### DIFF
--- a/core/java/com/android/internal/gmscompat/PlayStoreHooks.java
+++ b/core/java/com/android/internal/gmscompat/PlayStoreHooks.java
@@ -126,6 +126,7 @@ public final class PlayStoreHooks {
                         .setSmallIcon(context.getApplicationInfo().icon)
                         .setContentTitle(context.getText(R.string.gmscompat_notif_channel_action_required))
                         .setContentIntent(pi)
+                        .setOngoing(true)
                         .setAutoCancel(true)
                         .build();
 


### PR DESCRIPTION
Play Store will wait for confirmation indefinitely if notification is dismissed.
Ongoing notifications can't be dismissed (swiped away) by the user.