### PR TITLE
gmscompat: fix push notifications in secondary user profiles

### DIFF
--- a/core/java/android/os/UserManager.java
+++ b/core/java/android/os/UserManager.java
@@ -2527,6 +2527,9 @@ public class UserManager {
     @RequiresPermission(anyOf = {Manifest.permission.MANAGE_USERS,
             Manifest.permission.INTERACT_ACROSS_USERS}, conditional = true)
     public boolean isUserUnlocked(@UserIdInt int userId) {
+        if (GmsCompat.isEnabled()) {
+            return true;
+        }
         return mIsUserUnlockedCache.query(userId);
     }
 


### PR DESCRIPTION
`UserManager.isUserUnlocked(userId)` returns whether a user exited the Direct Boot mode.
This method requires a restricted permission if userId parameter differs from the current userId.
GMS called this method with userId 0 in both primary (`userId == 0`) and secondary (`userId != 0`)
profiles. userId was always 0 likely because of the stubbed out
`UserManager.getUserSerialNumber(userId)`,
which always returned 0 as a workaround to a different issue.

Tested with [Slack's "Troubleshoot Notifications" tool](https://slack.com/help/articles/360001559367-Troubleshoot-Slack-notifications#android-2).

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/734