### PR TITLE
gmscompat: set foregroundServiceType of location services

### DIFF
--- a/core/java/android/content/pm/parsing/component/ParsedServiceUtils.java
+++ b/core/java/android/content/pm/parsing/component/ParsedServiceUtils.java
@@ -32,6 +32,7 @@ import android.content.res.XmlResourceParser;
 import android.os.Build;
 
 import com.android.internal.R;
+import com.android.internal.gmscompat.GmsInfo;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -90,6 +91,11 @@ public class ParsedServiceUtils {
                     R.styleable.AndroidManifestService_foregroundServiceType,
                     ServiceInfo.FOREGROUND_SERVICE_TYPE_NONE);
 
+            if (GmsInfo.PACKAGE_GMS.equals(packageName)) {
+                if (service.getName().startsWith("com.google.android.location")) {
+                    service.foregroundServiceType |= ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION;
+                }
+            }
             service.flags |= flag(ServiceInfo.FLAG_STOP_WITH_TASK,
                     R.styleable.AndroidManifestService_stopWithTask, sa)
                     | flag(ServiceInfo.FLAG_ISOLATED_PROCESS,


### PR DESCRIPTION
Without it, location access gets throttled after a few minutes.

Make sure to reinstall GMS so that its AndroidManifest is reparsed (it also gets reparsed during the OS upgrade).

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/635