### PR TITLE
Add a config to state whether a device supports increased touch sensi…

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -3305,6 +3305,9 @@
     <!-- Whether device supports double tap to wake -->
     <bool name="config_supportDoubleTapWake">false</bool>
 
+    <!-- Whether device supports increased touch sensitvity -->
+    <bool name="config_supportGloveMode">false</bool>
+
     <!-- The RadioAccessFamilies supported by the device.
          Empty is viewed as "all".  Only used on devices which
          don't support RIL_REQUEST_GET_RADIO_CAPABILITY

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -2871,6 +2871,7 @@
   <java-symbol type="color" name="chooser_row_divider" />
   <java-symbol type="layout" name="chooser_row_direct_share" />
   <java-symbol type="bool" name="config_supportDoubleTapWake" />
+  <java-symbol type="bool" name="config_supportGloveMode" />
   <java-symbol type="drawable" name="ic_perm_device_info" />
   <java-symbol type="string" name="config_radio_access_family" />
   <java-symbol type="string" name="notification_inbox_ellipsis" />


### PR DESCRIPTION
…tivity. (#2)

This is the partner commit to the addition of an option in Settings for
the same feature. This config can be enabled by an overlay for devices
that support increased touch sensitivity (otherwise known as "Glove
Mode") via the persist.vendor.touch_sensitivity_mode system property.

Signed-off-by: Diab Neiroukh <lazerl0rd@thezest.dev>