### PR TITLE
gmscompat: add recently bound pids to getRunningAppProcesses() result

### DIFF
--- a/core/java/android/app/ActivityManager.java
+++ b/core/java/android/app/ActivityManager.java
@@ -3373,7 +3373,11 @@ public class ActivityManager {
      */
     public List<RunningAppProcessInfo> getRunningAppProcesses() {
         try {
-            return getService().getRunningAppProcesses();
+            List<RunningAppProcessInfo> res = getService().getRunningAppProcesses();
+            if (GmsCompat.isPlayServices()) {
+                res = GmsHooks.addRecentlyBoundPids(mContext, res);
+            }
+            return res;
         } catch (RemoteException e) {
             throw e.rethrowFromSystemServer();
         }

--- a/core/java/android/app/compat/gms/GmsCompat.java
+++ b/core/java/android/app/compat/gms/GmsCompat.java
@@ -80,6 +80,7 @@ public final class GmsCompat {
     // no need to declare these fields as volatile, they are written when app has only the main thread
     private static boolean isGmsCompatEnabled;
     private static boolean isDynamiteClientEnabled;
+    private static boolean isPlayServices;
     private static boolean isPlayStore;
 
     // Static only
@@ -92,6 +93,11 @@ public final class GmsCompat {
     /** @hide */
     public static boolean isDynamiteClient() {
         return isDynamiteClientEnabled;
+    }
+
+    /** @hide */
+    public static boolean isPlayServices() {
+        return isPlayServices;
     }
 
     /** @hide */
@@ -136,7 +142,9 @@ public final class GmsCompat {
         isDynamiteClientEnabled = isChangeEnabled("GMS_UNPRIVILEGED_DYNAMITE_CLIENT", GMS_UNPRIVILEGED_DYNAMITE_CLIENT);
         if (isGmsCompatEnabled) {
             // certificate is already checked if isGmsCompatEnabled is set
-            isPlayStore = GmsInfo.PACKAGE_PLAY_STORE.equals(app.getPackageName());
+            String pkg = app.getPackageName();
+            isPlayServices = GmsInfo.PACKAGE_GMS.equals(pkg);
+            isPlayStore = GmsInfo.PACKAGE_PLAY_STORE.equals(pkg);
         }
     }
 

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -17,6 +17,7 @@
 package com.android.internal.gmscompat;
 
 import android.annotation.SuppressLint;
+import android.app.ActivityManager.RunningAppProcessInfo;
 import android.app.ActivityThread;
 import android.app.Application;
 import android.app.Notification;
@@ -29,21 +30,23 @@ import android.app.compat.gms.GmsCompat;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageInstaller;
 import android.content.pm.PackageManager;
 import android.content.pm.SharedLibraryInfo;
 import android.os.Build;
 import android.os.Process;
+import android.os.SystemClock;
 import android.os.UserHandle;
 import android.os.UserManager;
 import android.provider.Settings;
 import android.util.Log;
+import android.util.SparseArray;
 import android.webkit.WebView;
 
 import com.android.internal.R;
 import com.android.internal.gmscompat.dynamite.GmsDynamiteHooks;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -229,5 +232,102 @@ public final class GmsHooks {
     // ContextImpl#sendBroadcastAsUser
     public static UserHandle getUserHandle(UserHandle user) {
         return GmsCompat.isEnabled() ? Process.myUserHandle() : user;
+    }
+
+    static class RecentBinderPid implements Comparable<RecentBinderPid> {
+        int pid;
+        int uid;
+        long lastSeen;
+        volatile String[] packageNames; // lazily inited
+
+        static final int MAX_MAP_SIZE = 50;
+        static final int MAP_SIZE_TRIM_TO = 40;
+        static final SparseArray<RecentBinderPid> map = new SparseArray(MAX_MAP_SIZE + 1);
+
+        public int compareTo(RecentBinderPid b) {
+            return Long.compare(b.lastSeen, lastSeen); // newest come first
+        }
+    }
+
+    // Remember recent Binder peers to include them in the result of ActivityManager.getRunningAppProcesses()
+    // Binder#execTransact(int, long, long, int)
+    public static void onBinderTransaction(int pid, int uid) {
+        SparseArray<RecentBinderPid> map = RecentBinderPid.map;
+        synchronized (map) {
+            RecentBinderPid rbp = map.get(pid);
+            if (rbp != null) {
+                if (rbp.uid != uid) { // pid was reused
+                    rbp = null;
+                }
+            }
+            if (rbp == null) {
+                rbp = new RecentBinderPid();
+                rbp.pid = pid;
+                rbp.uid = uid;
+                map.put(pid, rbp);
+            }
+            rbp.lastSeen = SystemClock.uptimeMillis();
+
+            int mapSize = map.size();
+            if (mapSize <= RecentBinderPid.MAX_MAP_SIZE) {
+                return;
+            }
+            RecentBinderPid[] arr = new RecentBinderPid[mapSize];
+            for (int i = 0; i < mapSize; ++i) {
+                arr[i] = map.valueAt(i);
+            }
+            // sorted by lastSeen field in reverse order
+            Arrays.sort(arr);
+            map.clear();
+            for (int i = 0; i < RecentBinderPid.MAP_SIZE_TRIM_TO; ++i) {
+                RecentBinderPid e = arr[i];
+                map.put(e.pid, e);
+            }
+        }
+    }
+
+    // Play Games Services relies on getRunningAppProcesses() to figure out whether its client is running.
+    // This workaround is racy, because unprivileged apps don't know whether arbitrary pid is alive.
+    // ActivityManager#getRunningAppProcesses()
+    public static ArrayList<RunningAppProcessInfo> addRecentlyBoundPids(Context context,
+                                                                        List<RunningAppProcessInfo> orig) {
+        final RecentBinderPid[] binderPids;
+        final int binderPidsCount;
+        // copy to array to avoid long lock contention with Binder.execTransact(),
+        // there are expensive getPackagesForUid() calls below
+        {
+            SparseArray<RecentBinderPid> map = RecentBinderPid.map;
+            synchronized (map) {
+                binderPidsCount = map.size();
+                binderPids = new RecentBinderPid[binderPidsCount];
+                for (int i = 0; i < binderPidsCount; ++i) {
+                    binderPids[i] = map.valueAt(i);
+                }
+            }
+        }
+        PackageManager pm = context.getPackageManager();
+        ArrayList<RunningAppProcessInfo> res = new ArrayList<>(orig.size() + binderPidsCount);
+        res.addAll(orig);
+        for (int i = 0; i < binderPidsCount; ++i) {
+            RecentBinderPid rbp = binderPids[i];
+            String[] pkgs = rbp.packageNames;
+            if (pkgs == null) {
+                pkgs = pm.getPackagesForUid(rbp.uid);
+                if (pkgs == null || pkgs.length == 0) {
+                    continue;
+                }
+                // this field is volatile
+                rbp.packageNames = pkgs;
+            }
+            RunningAppProcessInfo pi = new RunningAppProcessInfo();
+            // these fields are immutable after publication
+            pi.pid = rbp.pid;
+            pi.uid = rbp.uid;
+            pi.processName = pkgs[0];
+            pi.pkgList = pkgs;
+            pi.importance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
+            res.add(pi);
+        }
+        return res;
     }
 }


### PR DESCRIPTION
Play Games Services relies on `ActivityManager.getRunningAppProcesses()` to figure out whether its client is running.
Unprivileged apps see only their own processes.
This workaround is racy (there is no permission to figure out whether pid is alive), but seems to work reliably.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/860