### PR TITLE
Allow PackageInstaller UI to become hidden if it starts another activity

### DIFF
--- a/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
+++ b/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
@@ -130,6 +130,7 @@ public class PackageInstallerActivity extends AlertActivity {
     // Would the mOk button be enabled if this activity would be resumed
     private boolean mEnableOk = false;
     private boolean mPermissionResultWasSet;
+    private boolean mAllowNextOnPause;
 
     private void startInstallConfirm() {
         View viewToEnable;
@@ -395,10 +396,21 @@ public class PackageInstallerActivity extends AlertActivity {
         // sometimes this activity becomes hidden after onPause(),
         // and the user is unable to bring it back
         if (!mPermissionResultWasSet && mSessionId != -1) {
-            mInstaller.setPermissionsResult(mSessionId, false);
-            mPermissionResultWasSet = true;
-            finish();
+            if (mAllowNextOnPause) {
+                mAllowNextOnPause = false;
+            } else {
+                if (!isFinishing()) {
+                    finish();
+                }
+            }
         }
+    }
+
+    // handles startActivity() calls too
+    @Override
+    public void startActivityForResult(Intent intent, int requestCode, Bundle options) {
+        mAllowNextOnPause = true;
+        super.startActivityForResult(intent, requestCode, options);
     }
 
     @Override
@@ -413,6 +425,9 @@ public class PackageInstallerActivity extends AlertActivity {
         super.onDestroy();
         while (!mActiveUnknownSourcesListeners.isEmpty()) {
             unregister(mActiveUnknownSourcesListeners.get(0));
+        }
+        if (!mPermissionResultWasSet) {
+            mInstaller.setPermissionsResult(mSessionId, false);
         }
     }
 


### PR DESCRIPTION
In some cases, most commonly when the caller doesn't yet have the
REQUEST_INSTALL_PACKAGES permission, PackageInstaller UI gets paused as
it calls startActivity() as part of the confirmation process.
Previous [change](https://github.com/GrapheneOS/platform_frameworks_base/commit/11e3682d008fe4d32fa8f0fc85e1f879e3b0e3c6) failed to take this into account, which caused callers to
receive the "confirmation declined" result immediately.