### PR TITLE
gmscompat: enable Play {Asset, Feature} Delivery

### DIFF
--- a/core/java/android/app/ActivityManager.java
+++ b/core/java/android/app/ActivityManager.java
@@ -3374,7 +3374,7 @@ public class ActivityManager {
     public List<RunningAppProcessInfo> getRunningAppProcesses() {
         try {
             List<RunningAppProcessInfo> res = getService().getRunningAppProcesses();
-            if (GmsCompat.isPlayServices()) {
+            if (GmsCompat.isEnabled()) {
                 res = GmsHooks.addRecentlyBoundPids(mContext, res);
             }
             return res;

--- a/core/java/android/os/Binder.java
+++ b/core/java/android/os/Binder.java
@@ -1142,7 +1142,7 @@ public class Binder implements IBinder {
         // At that point, the parcel request headers haven't been parsed so we do not know what
         // WorkSource the caller has set. Use calling uid as the default.
         final int callingUid = Binder.getCallingUid();
-        if (GmsCompat.isPlayServices()) {
+        if (GmsCompat.isEnabled()) {
             if (callingUid >= Process.FIRST_APPLICATION_UID && callingUid != mPreviousUid) {
                 // harmless race
                 mPreviousUid = callingUid;


### PR DESCRIPTION
Play Store uses a similar getRunningAppProcesses()-based "is client foreground"
check as Play Services does, so enable the same workaround for it as well.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/894