### PR TITLE
gmscompat: don't stub out PackageManager.getSharedLibraries()

### DIFF
--- a/core/java/android/app/ApplicationPackageManager.java
+++ b/core/java/android/app/ApplicationPackageManager.java
@@ -579,6 +579,10 @@ public class ApplicationPackageManager extends PackageManager {
     /** @hide */
     @Override
     public @NonNull List<SharedLibraryInfo> getSharedLibraries(int flags) {
+        if (GmsCompat.isEnabled()) {
+            // MATCH_ANY_USER requires privileged INTERACT_ACROSS_USERS permission
+            flags &= (~ MATCH_ANY_USER);
+        }
         return getSharedLibrariesAsUser(flags, getUserId());
     }
 
@@ -586,10 +590,6 @@ public class ApplicationPackageManager extends PackageManager {
     @Override
     @SuppressWarnings("unchecked")
     public @NonNull List<SharedLibraryInfo> getSharedLibrariesAsUser(int flags, int userId) {
-        if (GmsCompat.isEnabled()) {
-            return GmsHooks.getSharedLibrariesAsUser();
-        }
-
         try {
             ParceledListSlice<SharedLibraryInfo> sharedLibs = mPM.getSharedLibraries(
                     mContext.getOpPackageName(), flags, userId);

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -190,13 +190,6 @@ public final class GmsHooks {
         return serial;
     }
 
-    // Report no shared libraries
-    // ApplicationPackageManager#getSharedLibrariesAsUser(int, int)
-    public static List<SharedLibraryInfo> getSharedLibrariesAsUser() {
-        // TODO: Report standard Pixel libraries?
-        return Collections.emptyList();
-    }
-
     // Only get package info for current user
     // ApplicationPackageManager#getPackageInfo(VersionedPackage, int)
     // ApplicationPackageManager#getPackageInfoAsUser(String, int, int)


### PR DESCRIPTION
Play Store uses list of shared libraries to filter out apps with missing dependencies.