### PR TITLE
gmscompat: improve userId-related shims

### DIFF
--- a/core/java/android/app/ActivityManager.java
+++ b/core/java/android/app/ActivityManager.java
@@ -85,6 +85,7 @@ import android.window.TaskSnapshot;
 import com.android.internal.app.LocalePicker;
 import com.android.internal.app.procstats.ProcessStats;
 import com.android.internal.gmscompat.GmsHooks;
+import com.android.internal.gmscompat.GmsUserHooks;
 import com.android.internal.os.RoSystemProperties;
 import com.android.internal.os.TransferPipe;
 import com.android.internal.util.FastPrintWriter;
@@ -4044,7 +4045,7 @@ public class ActivityManager {
     })
     public static int getCurrentUser() {
         if (GmsCompat.isEnabled()) {
-            return GmsHooks.getCurrentUser();
+            return GmsUserHooks.getCurrentUser();
         }
 
         try {
@@ -4213,9 +4214,9 @@ public class ActivityManager {
     @UnsupportedAppUsage
     public boolean isUserRunning(int userId) {
         if (GmsCompat.isEnabled()) {
-            // GMS sees only the current user
-            return true;
+            return GmsUserHooks.isUserRunning(userId);
         }
+
         try {
             return getService().isUserRunning(userId, 0);
         } catch (RemoteException e) {

--- a/core/java/android/app/ContextImpl.java
+++ b/core/java/android/app/ContextImpl.java
@@ -95,7 +95,6 @@ import android.window.WindowContext;
 import android.window.WindowTokenClient;
 
 import com.android.internal.annotations.GuardedBy;
-import com.android.internal.gmscompat.GmsHooks;
 import com.android.internal.util.Preconditions;
 
 import dalvik.system.BlockGuard;
@@ -1386,8 +1385,6 @@ class ContextImpl extends Context {
 
     @Override
     public void sendBroadcastAsUser(Intent intent, UserHandle user) {
-        user = GmsHooks.getUserHandle(user);
-
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         try {
             intent.prepareToLeaveProcess(this);
@@ -1409,8 +1406,6 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcastAsUser(Intent intent, UserHandle user, String receiverPermission,
             Bundle options) {
-        user = GmsHooks.getUserHandle(user);
-
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         String[] receiverPermissions = receiverPermission == null ? null
                 : new String[] {receiverPermission};
@@ -1429,8 +1424,6 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcastAsUser(Intent intent, UserHandle user,
             String receiverPermission, int appOp) {
-        user = GmsHooks.getUserHandle(user);
-
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         String[] receiverPermissions = receiverPermission == null ? null
                 : new String[] {receiverPermission};
@@ -1465,8 +1458,6 @@ class ContextImpl extends Context {
     public void sendOrderedBroadcastAsUser(Intent intent, UserHandle user,
             String receiverPermission, int appOp, Bundle options, BroadcastReceiver resultReceiver,
             Handler scheduler, int initialCode, String initialData, Bundle initialExtras) {
-        user = GmsHooks.getUserHandle(user);
-
         IIntentReceiver rd = null;
         if (resultReceiver != null) {
             if (mPackageInfo != null) {

--- a/core/java/android/os/UserHandle.java
+++ b/core/java/android/os/UserHandle.java
@@ -22,6 +22,7 @@ import android.annotation.Nullable;
 import android.annotation.SystemApi;
 import android.annotation.TestApi;
 import android.annotation.UserIdInt;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 
 import java.io.PrintWriter;
@@ -513,6 +514,10 @@ public final class UserHandle implements Parcelable {
     @Deprecated
     @SystemApi
     public boolean isOwner() {
+        if (GmsCompat.isEnabled()) {
+            return isSystem();
+        }
+
         return this.equals(OWNER);
     }
 
@@ -522,6 +527,11 @@ public final class UserHandle implements Parcelable {
      */
     @SystemApi
     public boolean isSystem() {
+        if (GmsCompat.isEnabled()) {
+            // "system" user means "primary" ("Owner") user
+            return true;
+        }
+
         return this.equals(SYSTEM);
     }
 

--- a/core/java/android/os/UserManager.java
+++ b/core/java/android/os/UserManager.java
@@ -59,7 +59,7 @@ import android.util.ArraySet;
 import android.view.WindowManager.LayoutParams;
 
 import com.android.internal.R;
-import com.android.internal.gmscompat.GmsHooks;
+import com.android.internal.gmscompat.GmsUserHooks;
 import com.android.internal.os.RoSystemProperties;
 import com.android.internal.util.FrameworkStatsLog;
 
@@ -2205,10 +2205,6 @@ public class UserManager {
     @RequiresPermission(anyOf = {Manifest.permission.MANAGE_USERS,
             Manifest.permission.CREATE_USERS})
     public boolean isGuestUser(@UserIdInt int userId) {
-        if (GmsCompat.isEnabled()) {
-            return false;
-        }
-
         UserInfo user = getUserInfo(userId);
         return user != null && user.isGuest();
     }
@@ -2223,10 +2219,6 @@ public class UserManager {
     @RequiresPermission(anyOf = {Manifest.permission.MANAGE_USERS,
             Manifest.permission.CREATE_USERS})
     public boolean isGuestUser() {
-        if (GmsCompat.isEnabled()) {
-            return false;
-        }
-
         UserInfo user = getUserInfo(UserHandle.myUserId());
         return user != null && user.isGuest();
     }
@@ -2527,9 +2519,6 @@ public class UserManager {
     @RequiresPermission(anyOf = {Manifest.permission.MANAGE_USERS,
             Manifest.permission.INTERACT_ACROSS_USERS}, conditional = true)
     public boolean isUserUnlocked(@UserIdInt int userId) {
-        if (GmsCompat.isEnabled()) {
-            return mIsUserUnlockedCache.query(mUserId);
-        }
         return mIsUserUnlockedCache.query(userId);
     }
 
@@ -2616,6 +2605,10 @@ public class UserManager {
     @RequiresPermission(anyOf = {Manifest.permission.MANAGE_USERS,
             Manifest.permission.CREATE_USERS})
     public UserInfo getUserInfo(@UserIdInt int userId) {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.getUserInfo(userId);
+        }
+
         try {
             return mService.getUserInfo(userId);
         } catch (RemoteException re) {
@@ -3431,10 +3424,6 @@ public class UserManager {
             android.Manifest.permission.CREATE_USERS
     })
     public int getUserCount() {
-        if (GmsCompat.isEnabled()) {
-            return 1;
-        }
-
         List<UserInfo> users = getUsers();
         return users != null ? users.size() : 1;
     }
@@ -3515,6 +3504,10 @@ public class UserManager {
     })
     public @NonNull List<UserInfo> getUsers(boolean excludePartial, boolean excludeDying,
             boolean excludePreCreated) {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.getUsers();
+        }
+
         try {
             return mService.getUsers(excludePartial, excludeDying, excludePreCreated);
         } catch (RemoteException re) {
@@ -3557,10 +3550,6 @@ public class UserManager {
             android.Manifest.permission.CREATE_USERS
     })
     public long[] getSerialNumbersOfUsers(boolean excludeDying) {
-        if (GmsCompat.isEnabled()) {
-            return GmsHooks.getSerialNumbersOfUsers(this);
-        }
-
         List<UserInfo> users = getUsers(/* excludePartial= */ true, excludeDying,
                 /* excludePreCreated= */ true);
         long[] result = new long[users.size()];
@@ -3914,10 +3903,6 @@ public class UserManager {
             android.Manifest.permission.INTERACT_ACROSS_USERS
     })
     public @Nullable UserHandle getProfileParent(@NonNull UserHandle user) {
-        if (GmsCompat.isEnabled()) {
-            return null;
-        }
-
         UserInfo info = getProfileParent(user.getIdentifier());
 
         if (info == null) {
@@ -4536,8 +4521,7 @@ public class UserManager {
     @UnsupportedAppUsage
     public int getUserSerialNumber(@UserIdInt int userId) {
         if (GmsCompat.isEnabled()) {
-            // com.google.android.gms.persistent: java.lang.IllegalStateException - com.google.android.gms.gcm.GcmProxyIntentOperation.b
-            return 0;
+            return GmsUserHooks.getUserSerialNumber(userId);
         }
 
         try {
@@ -4558,6 +4542,10 @@ public class UserManager {
      */
     @UnsupportedAppUsage
     public @UserIdInt int getUserHandle(int userSerialNumber) {
+        if (GmsCompat.isEnabled()) {
+            return GmsUserHooks.getUserHandle(userSerialNumber);
+        }
+
         try {
             return mService.getUserHandle(userSerialNumber);
         } catch (RemoteException re) {

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -32,8 +32,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Process;
 import android.os.SystemClock;
-import android.os.UserHandle;
-import android.os.UserManager;
 import android.provider.Settings;
 import android.util.Log;
 import android.util.SparseArray;
@@ -106,18 +104,6 @@ public final class GmsHooks {
      * API shims
      */
 
-    // Report a single user on the system
-    // UserManager#getSerialNumbersOfUsers(boolean)
-    public static long[] getSerialNumbersOfUsers(UserManager userManager) {
-        return new long[] { userManager.getSerialNumberForUser(Process.myUserHandle()) };
-    }
-
-    // Current user is always active
-    // ActivityManager#getCurrentUser()
-    public static int getCurrentUser() {
-        return Process.myUserHandle().getIdentifier();
-    }
-
     /**
      * Use the per-app SSAID as a random serial number for SafetyNet. This doesn't necessarily make
      * pass, but at least it retusn a valid "failed" response and stops spamming device key
@@ -175,13 +161,6 @@ public final class GmsHooks {
         } else if (GmsCompat.isDynamiteClient()) {
             GmsDynamiteHooks.initClientApp();
         }
-    }
-
-    // Redirect cross-user interactions to current user
-    // ContextImpl#sendOrderedBroadcastAsUser
-    // ContextImpl#sendBroadcastAsUser
-    public static UserHandle getUserHandle(UserHandle user) {
-        return GmsCompat.isEnabled() ? Process.myUserHandle() : user;
     }
 
     static class RecentBinderPid implements Comparable<RecentBinderPid> {

--- a/core/java/com/android/internal/gmscompat/GmsUserHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsUserHooks.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat;
+
+import android.content.pm.UserInfo;
+import android.os.UserHandle;
+import android.os.UserManager;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * GMS tries to interact across user profiles, which requires privileged permissions.
+ * As a workaround, a pseudo-single-user environment is constructed by hiding non-current users
+ * and marking the current user as the primary ("Owner") user.
+ */
+public class GmsUserHooks {
+
+    private static int getUserId() {
+        return UserHandle.myUserId();
+    }
+
+    private static void checkUserId(int userId) {
+        if (userId != getUserId()) {
+            throw new IllegalStateException("unexpected userId " + userId);
+        }
+    }
+
+    private static int getUserSerialNumber() {
+        // GMS has several hardcoded (userSerialNumber == 0) checks
+        return 0;
+    }
+
+    private static UserInfo getUserInfo() {
+        // obtaining UserInfo is a privileged operation (even for the current user)
+        UserInfo ui = new UserInfo();
+        ui.id = getUserId();
+        ui.serialNumber = getUserSerialNumber();
+        // "system" means "primary" ("Owner") user
+        ui.userType = UserManager.USER_TYPE_FULL_SYSTEM;
+        ui.flags = UserInfo.FLAG_SYSTEM | UserInfo.FLAG_FULL;
+        return ui;
+    }
+
+    // ActivityManager#getCurrentUser()
+    public static int getCurrentUser() {
+        return getUserId();
+    }
+
+    // ActivityManager#isUserRunning(int)
+    public static boolean isUserRunning(int userId) {
+        checkUserId(userId);
+        return true;
+    }
+
+    // UserManager#getUserInfo(int)
+    public static UserInfo getUserInfo(int userId) {
+        checkUserId(userId);
+        return getUserInfo();
+    }
+
+    // UserManager#getUserHandle(int)
+    public static int getUserHandle(int userSerialNumber) {
+        if (userSerialNumber != getUserSerialNumber()) {
+            throw new IllegalStateException("unexpected userSerialNumber " + userSerialNumber);
+        }
+        return getUserId();
+    }
+
+    // UserManager#getUsers(boolean, boolean, boolean)
+    public static List<UserInfo> getUsers() {
+        return Collections.singletonList(getUserInfo());
+    }
+
+    // UserManager#getUserSerialNumber(int)
+    public static int getUserSerialNumber(int userId) {
+        checkUserId(userId);
+        return getUserSerialNumber();
+    }
+
+    private GmsUserHooks() {}
+}


### PR DESCRIPTION
Current approach is fragile: GMS always obtains UserHandle of the primary ("Owner") user and
tries to use it, which is a privileged operation if GMS is installed in the non-primary user profile.
It's worked around by unconditionally replacing UserHandle with the current one in all methods that
GMS calls, which will break each time new GMS version makes use of a new UserHandle-accepting method.

With the new approach, GMS gets access only to the current UserHandle which is made
to look like a UserHandle of the primary user.