### PR TITLE
gmscompat: hide privileged FontManager service

### DIFF
--- a/core/java/android/app/ContextImpl.java
+++ b/core/java/android/app/ContextImpl.java
@@ -2054,6 +2054,7 @@ class ContextImpl extends Context {
                 case Context.APP_INTEGRITY_SERVICE:
                 // used for factory reset protection
                 case Context.PERSISTENT_DATA_BLOCK_SERVICE:
+                case Context.FONT_SERVICE:
                     // these privileged services are null-checked by GMS
                     return null;
             }


### PR DESCRIPTION
GMS tries to update fonts, which is a privileged operation that leads to a crash.
If the `FontManager` is `null`, no such attempt is made.