### PR TITLE
Spoof build fingerprint for Google Play Services

### DIFF
--- a/core/java/android/app/Instrumentation.java
+++ b/core/java/android/app/Instrumentation.java
@@ -57,6 +57,7 @@ import android.view.WindowManagerGlobal;
 
 import com.android.internal.content.ReferrerIntent;
 
+import com.android.internal.gmscompat.AttestationHooks;
 import com.android.internal.gmscompat.GmsHooks;
 
 import java.io.File;
@@ -1191,6 +1192,7 @@ public class Instrumentation {
                 .instantiateApplication(cl, className);
         app.attach(context);
         GmsHooks.initApplicationBeforeOnCreate(app);
+        AttestationHooks.initApplicationBeforeOnCreate(app);
         return app;
     }
     
@@ -1209,6 +1211,7 @@ public class Instrumentation {
         Application app = (Application)clazz.newInstance();
         app.attach(context);
         GmsHooks.initApplicationBeforeOnCreate(app);
+        AttestationHooks.initApplicationBeforeOnCreate(app);
         return app;
     }
 

--- a/core/java/com/android/internal/gmscompat/AttestationHooks.java
+++ b/core/java/com/android/internal/gmscompat/AttestationHooks.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.gmscompat;
+
+import android.app.Application;
+import android.os.Build;
+import android.os.SystemProperties;
+import android.util.Log;
+
+import java.lang.reflect.Field;
+
+/** @hide */
+public final class AttestationHooks {
+    private static final String TAG = "GmsCompat/Attestation";
+
+    private static final String PRODUCT_STOCK_FINGERPRINT =
+            SystemProperties.get("ro.build.stock_fingerprint");
+
+    private AttestationHooks() { }
+
+    private static void setBuildField(String key, String value) {
+        try {
+            // Unlock
+            Field field = Build.class.getDeclaredField(key);
+            field.setAccessible(true);
+
+            // Edit
+            field.set(null, value);
+
+            // Lock
+            field.setAccessible(false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            Log.e(TAG, "Failed to spoof Build." + key, e);
+        }
+    }
+
+    private static void spoofBuildGms() {
+        // Set fingerprint for SafetyNet CTS profile
+        if (PRODUCT_STOCK_FINGERPRINT.length() > 0) {
+            setBuildField("FINGERPRINT", PRODUCT_STOCK_FINGERPRINT);
+        }
+    }
+
+    public static void initApplicationBeforeOnCreate(Application app) {
+        if (GmsInfo.PACKAGE_GMS.equals(app.getPackageName())) {
+            spoofBuildGms();
+        }
+    }
+}


### PR DESCRIPTION
SafetyNet's CTS profile attestation checks whether Build.FINGERPRINT
matches that of the device's stock OS, which has passed CTS testing.
Spoof the fingerprint for Google Play Services to help pass SafetyNet.

We used to set the real system build fingerprint to the stock one, but
Android relies on each build having a unique fingerprint in order to
clear the correct caches and update persistent state for system changes.
On devices that no longer receive updates from the OEM, the build
fingerprint never changes and Android doesn't account for updates
correctly, which causes issues when updating without wiping data.
Only spoofing the fingerprint for Google Play Services fixes this issue.

Corresponding vendor commit:
"Only use stock build fingerprint for Google Play Services"

NB: This code is under the gmscompat package, but it does not depend on
any code from gmscompat.

Change-Id: I26a2498eb2e2163933303b03f6d516e5fb30fe51