### PR TITLE
Ignore allowbackup on all API versions

### DIFF
--- a/services/backup/java/com/android/server/backup/utils/BackupEligibilityRules.java
+++ b/services/backup/java/com/android/server/backup/utils/BackupEligibilityRules.java
@@ -78,7 +78,7 @@ public class BackupEligibilityRules {
      */
     @ChangeId
     @Overridable
-    @EnabledSince(targetSdkVersion = Build.VERSION_CODES.S)
+    @EnabledSince(targetSdkVersion = Build.VERSION_CODES.BASE)
     static final long IGNORE_ALLOW_BACKUP_IN_D2D = 183147249L;
 
     public static BackupEligibilityRules forBackup(PackageManager packageManager,


### PR DESCRIPTION
This changes the backup eligibility rules so that the new feature that ignores allowbackup for D2D backups is extended to apply to applications of all API versions and not just those targeting Android 12 or later.

Many applications seem to set allowbackup="false" for no reason, and this allows the user to properly backup all application data with SeedVault and not lose data if the device is lost or destroyed.