### PR TITLE
gmscompat: fix false-negative "can GMS start an Activity" check

### DIFF
--- a/core/java/android/app/ContextImpl.java
+++ b/core/java/android/app/ContextImpl.java
@@ -1093,13 +1093,6 @@ class ContextImpl extends Context {
                             + " context requires the FLAG_ACTIVITY_NEW_TASK flag."
                             + " Is this really what you want?");
         }
-
-        if (GmsCompat.isEnabled()) {
-            if (GmsHooks.startActivity(intent, options)) {
-                return;
-            }
-        }
-
         mMainThread.getInstrumentation().execStartActivity(
                 getOuterContext(), mMainThread.getApplicationThread(), null,
                 (Activity) null, intent, -1, options);

--- a/core/java/android/app/Instrumentation.java
+++ b/core/java/android/app/Instrumentation.java
@@ -57,6 +57,7 @@ import android.view.Window;
 import android.view.WindowManagerGlobal;
 
 import com.android.internal.content.ReferrerIntent;
+import com.android.internal.gmscompat.GmsHooks;
 
 import java.io.File;
 import java.lang.annotation.Retention;
@@ -1763,6 +1764,11 @@ public class Instrumentation {
                     intent.resolveTypeIfNeeded(who.getContentResolver()), token,
                     target != null ? target.mEmbeddedID : null, requestCode, 0, null, options);
             checkStartActivityResult(result, intent);
+
+            if (GmsCompat.isEnabled()) {
+                GmsHooks.onActivityStart(result, intent, options);
+            }
+
         } catch (RemoteException e) {
             throw new RuntimeException("Failure from system", e);
         }

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -19,6 +19,7 @@ package com.android.internal.gmscompat;
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.ActivityManager;
 import android.app.ActivityManager.RunningAppProcessInfo;
 import android.app.ActivityThread;
 import android.app.Application;
@@ -238,10 +239,10 @@ public final class GmsHooks {
         return null;
     }
 
-    // ContextImpl#startActivity(Intent, Bundle)
-    public static boolean startActivity(Intent intent, Bundle options) {
-        if (ActivityThread.currentActivityThread().hasAtLeastOneResumedActivity()) {
-            return false;
+    // Instrumentation#execStartActivity(Context, IBinder, IBinder, Activity, Intent, int, Bundle)
+    public static void onActivityStart(int resultCode, Intent intent, Bundle options) {
+        if (resultCode != ActivityManager.START_ABORTED) {
+            return;
         }
 
         // handle background activity starts, which normally require a privileged permission
@@ -255,7 +256,6 @@ public final class GmsHooks {
         } catch (RemoteException e) {
             GmsCompatApp.callFailed(e);
         }
-        return true;
     }
 
     // Activity#onCreate(Bundle)

--- a/services/core/java/com/android/server/wm/ActivityStarter.java
+++ b/services/core/java/com/android/server/wm/ActivityStarter.java
@@ -706,6 +706,13 @@ class ActivityStarter {
                     res = waitResultIfNeeded(mRequest.waitResult, mLastStartActivityRecord,
                             launchingState);
                 }
+
+                if (res == START_ABORTED) {
+                    if (android.app.compat.gms.GmsCompat.isGmsApp(mRequest.callingPackage, mRequest.userId)) {
+                        return START_ABORTED;
+                    }
+                }
+
                 return getExternalResult(res);
             }
         } finally {


### PR DESCRIPTION
`hasAtLeastOneResumedActivity()` isn't a reliable check for whether an app can start an `Activity`.
`ActivityManagerService` has a much more complex set of checks that allow an app to start an `Activity`
even if it doesn't have any visible activities in case the user interacted with it (by tapping a notification, quick tile etc) shortly before the activity start request was made. Unfortunately, activity start is silently aborted if this check fails,
(no callback of any kind to the caller), requiring a patch to `ActivityManagerService`.