### PR TITLE
don't crash apps that try to access the "NETWORK" location provider; + hidden Play Store option to allow GMS updates

### DIFF
--- a/location/java/android/location/LocationManager.java
+++ b/location/java/android/location/LocationManager.java
@@ -1725,6 +1725,13 @@ public class LocationManager {
     public boolean hasProvider(@NonNull String provider) {
         Preconditions.checkArgument(provider != null, "invalid null provider");
 
+        if (NETWORK_PROVIDER.equals(provider)) {
+            if (!getAllProviders().contains(NETWORK_PROVIDER)) {
+                android.util.Log.d("LocationManager", "returning false from hasProvider(NETWORK_PROVIDER)");
+                return false;
+            }
+        }
+
         try {
             return mService.hasProvider(provider);
         } catch (RemoteException e) {

--- a/services/core/java/com/android/server/location/LocationManagerService.java
+++ b/services/core/java/com/android/server/location/LocationManagerService.java
@@ -317,6 +317,11 @@ public class LocationManagerService extends ILocationManager.Stub implements
             }
         }
 
+        if (NETWORK_PROVIDER.equals(providerName)) {
+            Log.d(TAG, "replaced NETWORK with the PASSIVE provider for uid " + Binder.getCallingUid());
+            return mPassiveManager;
+        }
+
         return null;
     }
 


### PR DESCRIPTION
Reroute them to the "PASSIVE" provider. Note that the "NETWORK" provider
is still not advertised as being present (it will not be returned
by `getAllProviders()`, `getBestProvider()`, `hasProvider()`).

There's a relevant system feature (`android.hardware.location.network`)
that is still advertised as being present to improve app compatibility.
Removing it would not make this change redundant, because there are apps
that try to use the "NETWORK" provider without declaring the need for
this feature or checking its presence at runtime.