### PR TITLE
add com.android.printspooler to indicator exemptions

### DIFF
--- a/core/java/android/permission/PermissionManager.java
+++ b/core/java/android/permission/PermissionManager.java
@@ -93,6 +93,7 @@ public final class PermissionManager {
     private static final String SYSTEM_PKG = "android";
     private static final String BLUETOOTH_PKG = "com.android.bluetooth";
     private static final String PHONE_SERVICES_PKG = "com.android.phone";
+    private static final String PRINT_SPOOLER_PKG = "com.android.printspooler";
 
     /**
      * Refuse to install package if groups of permissions are bad
@@ -944,6 +945,7 @@ public final class PermissionManager {
         pkgNames.add(SYSTEM_PKG);
         pkgNames.add(BLUETOOTH_PKG);
         pkgNames.add(PHONE_SERVICES_PKG);
+        pkgNames.add(PRINT_SPOOLER_PKG);
         for (int i = 0; i < INDICATOR_EXEMPTED_PACKAGES.length; i++) {
             String exemptedPackage = INDICATOR_EXEMPTED_PACKAGES[i];
             if (exemptedPackage != null) {


### PR DESCRIPTION
Location usage indicator can get triggered when sharing a file to a printer.