### PR TITLE
gmscompat: don't use "/proc/self/fd" paths for loading Dynamite modules

### DIFF
--- a/core/java/com/android/internal/gmscompat/dynamite/GmsDynamiteClientHooks.java
+++ b/core/java/com/android/internal/gmscompat/dynamite/GmsDynamiteClientHooks.java
@@ -121,7 +121,8 @@ public final class GmsDynamiteClientHooks {
         final String path = file.getPath();
 
         if (enabled && path.startsWith(gmsCoreDataPrefix)) {
-            return new File(modulePathToFdPath(path)).lastModified();
+            String fdPath = "/proc/self/fd/" + modulePathToFd(path).getInt$();
+            return new File(fdPath).lastModified();
         }
         return 0L;
     }
@@ -157,7 +158,7 @@ public final class GmsDynamiteClientHooks {
                 filePath = pathPart;
                 nativeLibRelPath = null;
             }
-            String fdFilePath = modulePathToFdPath(filePath);
+            String fdFilePath = "/gmscompat_fd_" + modulePathToFd(filePath).getInt$();
 
             pathParts[i] = nativeLibsPath ?
                 fdFilePath + zipFileSeparator + nativeLibRelPath :
@@ -169,11 +170,6 @@ public final class GmsDynamiteClientHooks {
             return path;
         }
         return String.join(File.pathSeparator, pathParts);
-    }
-
-    private static String modulePathToFdPath(String path) {
-        FileDescriptor fd = modulePathToFd(path);
-        return "/proc/self/fd/" + fd.getInt$();
     }
 
     // Returned file descriptor should never be closed, because it may be dup()-ed at any time by the native code


### PR DESCRIPTION
dup()-ing fd that is referred to by "/proc/self/fd" path isn't the same
as open()-ing that path. fd that is returned by dup() refers to the same
underlying file description and thus shares position and file status
flags with the original fd.

The ability to pass "/proc/self/fd" path instead of a file path
is an undocumented API on Android, but there are apps that depend on it.

Depends on
https://github.com/GrapheneOS/platform_art/pull/2
https://github.com/GrapheneOS/platform_bionic/pull/17
https://github.com/GrapheneOS/platform_libcore/pull/8
