### PR TITLE
Warn the user if they are using a prototype device.

### DIFF
--- a/core/res/res/values/strings.xml
+++ b/core/res/res/values/strings.xml
@@ -3728,6 +3728,11 @@
     <!-- Message of notification shown when serial console is enabled. [CHAR LIMIT=NONE] -->
     <string name="console_running_notification_message">Performance is impacted. To disable, check bootloader.</string>
 
+    <!-- Title of notification shown when a prototype device is detected. [CHAR LIMIT=NONE] -->
+    <string name="prototype_device_notification_title">Device is an engineering prototype</string>
+    <!-- Message of notification shown when a prototype device is detected. [CHAR LIMIT=NONE] -->
+    <string name="prototype_device_notification_message">Device security may be affected.</string>
+
     <!-- Title of notification shown when contaminant is detected on the USB port. [CHAR LIMIT=NONE] -->
     <string name="usb_contaminant_detected_title">Liquid or debris in USB port</string>
     <!-- Message of notification shown when contaminant is detected on the USB port. [CHAR LIMIT=NONE] -->

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -2075,6 +2075,8 @@
   <java-symbol type="string" name="test_harness_mode_notification_message" />
   <java-symbol type="string" name="console_running_notification_title" />
   <java-symbol type="string" name="console_running_notification_message" />
+  <java-symbol type="string" name="prototype_device_notification_title" />
+  <java-symbol type="string" name="prototype_device_notification_message" />
   <java-symbol type="string" name="taking_remote_bugreport_notification_title" />
   <java-symbol type="string" name="share_remote_bugreport_notification_title" />
   <java-symbol type="string" name="sharing_remote_bugreport_notification_title" />

--- a/proto/src/system_messages.proto
+++ b/proto/src/system_messages.proto
@@ -276,6 +276,10 @@ message SystemMessage {
     // Package: android
     NOTE_UNBLOCK_CAM_TOGGLE = 66;
 
+    // Inform the user that the device appears to be a prototype.
+    // Package: android
+    NOTE_PROTOTYPE_DETECTED = 67;
+
     // ADD_NEW_IDS_ABOVE_THIS_LINE
     // Legacy IDs with arbitrary values appear below
     // Legacy IDs existed as stable non-conflicting constants prior to the O release

--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -4795,6 +4795,8 @@ public class ActivityManagerService extends IActivityManager.Stub
         }
         // UART is on if init's console service is running, send a warning notification.
         showConsoleNotificationIfActive();
+        // If device is not a mass production (MP) variant, send a warning notification.
+        showPrototypeNotificationIfPrototype();
 
         t.traceEnd();
     }
@@ -4816,6 +4818,62 @@ public class ActivityManagerService extends IActivityManager.Stub
             isEnabled = true;
         }
         return isEnabled;
+    }
+
+    private static Boolean checkIfPixelDevice() {
+        // Check if device is a Pixel phone, since other OEMs may deal with hardware revisions differently
+        String[] pixelDevices = new String[]{"cheetah", "panther", "oriole", "raven", "bluejay", "redfin", "bramble", "barbet", "coral", "flame", "sunfish", "bonito", "sargo", "crosshatch", "blueline"};
+        boolean isPixelDevice = false;
+        for(String x : pixelDevices){
+            if(x.equals(Build.DEVICE)){
+                isPixelDevice = true;
+                break;
+            }
+        }
+        return isPixelDevice;
+    }
+
+    private static Boolean checkForPrototype() {
+        boolean isPrototype = false;
+        // MP1.0 is what all 3rd generation and newer Pixel devices have as their mass production revision.
+        // Account for future mass production device revisions by only checking for "MP".
+        // All devices with a blown secure boot fuse will have the bootloader report ro.boot.secure_boot as being in PRODUCTION mode.
+        // Engineering devices typically don't have a blown secure boot fuse as they are used for firmware development. 
+        if (checkIfPixelDevice() && (!SystemProperties.get("ro.revision").contains("MP")) || (!SystemProperties.get("ro.boot.secure_boot").equals("PRODUCTION"))) {
+            isPrototype = true;
+        }
+        return isPrototype;
+    }
+
+    private void showPrototypeNotificationIfPrototype() {
+
+        if (!checkForPrototype()) {
+            return;
+        }
+        String title = mContext
+                .getString(com.android.internal.R.string.prototype_device_notification_title);
+        String message = mContext
+                .getString(com.android.internal.R.string.prototype_device_notification_message);
+        Notification notification =
+                new Notification.Builder(mContext, SystemNotificationChannels.DEVELOPER)
+                        .setSmallIcon(com.android.internal.R.drawable.stat_sys_adb)
+                        .setWhen(0)
+                        .setOngoing(true)
+                        .setTicker(title)
+                        .setDefaults(0)  // please be quiet
+                        .setColor(mContext.getColor(
+                                com.android.internal.R.color
+                                        .system_notification_accent_color))
+                        .setContentTitle(title)
+                        .setContentText(message)
+                        .setVisibility(Notification.VISIBILITY_PUBLIC)
+                        .build();
+
+        NotificationManager notificationManager =
+                mContext.getSystemService(NotificationManager.class);
+        notificationManager.notifyAsUser(
+                null, SystemMessage.NOTE_PROTOTYPE_DETECTED, notification, UserHandle.ALL);
+
     }
 
     private void showConsoleNotificationIfActive() {


### PR DESCRIPTION
Consumer devices have "MP1.0" as their hardware revision usually. Devices stolen from Google will have "EVT", "PVT" or "DVT" set in "ro.revision" by the bootloader. Additionally, check the secure boot state prop set by the bootloader, "ro.boot.secure_boot", to ensure it is set to "1", as typically pre-production devices won't have a blown secure boot efuse, completely destroying any concept of verified boot. Check both props, if either check fails, notify the user.