### PR TITLE
control access to Android/obb directory with a GosPackageState flag

### DIFF
--- a/core/api/system-current.txt
+++ b/core/api/system-current.txt
@@ -2599,6 +2599,7 @@ package android.content.pm {
     field public static final int DFLAG_HAS_READ_MEDIA_IMAGES_DECLARATION = 1024; // 0x400
     field public static final int DFLAG_HAS_READ_MEDIA_VIDEO_DECLARATION = 2048; // 0x800
     field public static final int DFLAG_HAS_WRITE_EXTERNAL_STORAGE_DECLARATION = 32; // 0x20
+    field public static final int FLAG_ALLOW_ACCESS_TO_OBB_DIRECTORY = 2; // 0x2
     field public static final int FLAG_STORAGE_SCOPES_ENABLED = 1; // 0x1
     field public final int derivedFlags;
     field public final int flags;

--- a/core/java/android/content/pm/GosPackageState.java
+++ b/core/java/android/content/pm/GosPackageState.java
@@ -40,6 +40,8 @@ public final class GosPackageState implements Parcelable {
     public final int derivedFlags; // derived from persistent state, but not persisted themselves
 
     public static final int FLAG_STORAGE_SCOPES_ENABLED = 1;
+    // checked only if REQUEST_INSTALL_PACKAGES permission is granted
+    public static final int FLAG_ALLOW_ACCESS_TO_OBB_DIRECTORY = 1 << 1;
 
     // to distinguish between the case when no dflags are set and the case when dflags weren't calculated yet
     public static final int DFLAGS_SET = 1;

--- a/core/java/android/content/pm/GosPackageStatePm.java
+++ b/core/java/android/content/pm/GosPackageStatePm.java
@@ -20,6 +20,7 @@ import android.annotation.Nullable;
 
 import java.util.Arrays;
 
+import static android.content.pm.GosPackageState.FLAG_ALLOW_ACCESS_TO_OBB_DIRECTORY;
 import static android.content.pm.GosPackageState.FLAG_STORAGE_SCOPES_ENABLED;
 
 /**
@@ -83,7 +84,8 @@ public final class GosPackageStatePm {
         return new GosPackageState(flags, storageScopes, derivedFlags);
     }
 
-    private static final int FLAGS_VISIBLE_TO_THE_TARGET_PACKAGE = FLAG_STORAGE_SCOPES_ENABLED;
+    private static final int FLAGS_VISIBLE_TO_THE_TARGET_PACKAGE = FLAG_STORAGE_SCOPES_ENABLED
+            | FLAG_ALLOW_ACCESS_TO_OBB_DIRECTORY;
     private static final int DFLAGS_VISIBLE_TO_THE_TARGET_PACKAGE = -1;
 
     public GosPackageState externalVersionForTargetPackage(int derivedFlags) {

--- a/core/java/com/android/internal/gmscompat/PlayStoreHooks.java
+++ b/core/java/com/android/internal/gmscompat/PlayStoreHooks.java
@@ -27,6 +27,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.IntentSender;
+import android.content.pm.GosPackageState;
 import android.content.pm.IPackageDataObserver;
 import android.content.pm.IPackageDeleteObserver;
 import android.content.pm.PackageInstaller;
@@ -259,7 +260,10 @@ public final class PlayStoreHooks {
         String path = file.getPath();
 
         if (path.startsWith(obbDir) && !path.startsWith(playStoreObbDir)) {
-            if (!GmsCompat.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            GosPackageState ps = GosPackageState.get(GmsCompat.appContext().getPackageName());
+            boolean hasObbAccess = ps != null && ps.hasFlag(GosPackageState.FLAG_ALLOW_ACCESS_TO_OBB_DIRECTORY);
+
+            if (!hasObbAccess) {
                 try {
                     GmsCompatApp.iGms2Gca().showPlayStoreMissingObbPermissionNotification();
                 } catch (RemoteException e) {

--- a/services/core/java/com/android/server/StorageManagerService.java
+++ b/services/core/java/com/android/server/StorageManagerService.java
@@ -69,6 +69,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ApplicationInfo;
+import android.content.pm.GosPackageState;
 import android.content.pm.IPackageManager;
 import android.content.pm.IPackageMoveObserver;
 import android.content.pm.PackageManager;
@@ -4443,9 +4444,31 @@ class StorageManagerService extends IStorageManager.Stub
                     break;
                 }
             }
-            if ((hasInstall || hasInstallOp) && hasWrite) {
+            if (hasInstall && hasWrite) {
                 return StorageManager.MOUNT_MODE_EXTERNAL_INSTALLER;
             }
+
+            if (hasInstallOp) {
+                /*
+                Originally, previous check was `if ((hasInstall || hasInstallOp) && hasWrite)`.
+
+                This allowed MOUNT_MODE_EXTERNAL_INSTALLER (access to Android/obb directory)
+                to unprivileged installers that have WRITE_EXTERNAL_STORAGE permission, even if
+                they didn't actually needed to access Android/obb, and forced apps that don't need
+                access to external storage but need to access Android/obb to require this broad
+                storage access permission.
+
+                Use a special flag to control access to just Android/obb directory instead.
+                Toggle for this flag is in ExternalSourcesDetails.java in Settings app
+                (same screen that grants the REQUEST_INSTALL_PACKAGES permission)
+                 */
+
+                GosPackageState ps = mPmInternal.getGosPackageState(packageName, UserHandle.getUserId(uid));
+                if (ps != null && ps.hasFlag(GosPackageState.FLAG_ALLOW_ACCESS_TO_OBB_DIRECTORY)) {
+                    return StorageManager.MOUNT_MODE_EXTERNAL_INSTALLER;
+                }
+            }
+
             return StorageManager.MOUNT_MODE_EXTERNAL_DEFAULT;
         } catch (RemoteException e) {
             // Should not happen

--- a/services/core/java/com/android/server/pm/GosPackageStatePmHooks.java
+++ b/services/core/java/com/android/server/pm/GosPackageStatePmHooks.java
@@ -158,7 +158,9 @@ class GosPackageStatePmHooks {
             boolean allow = false;
             if (userId == UserHandle.getUserId(callingUid)) {
                 int callingAppId = UserHandle.getAppId(callingUid);
-                allow = callingAppId == pm.permissionControllerAppId;
+                allow = callingAppId == pm.permissionControllerAppId
+                        // appId of the Settings app is the same as SYSTEM_UID
+                        || callingAppId == Process.SYSTEM_UID;
             }
             if (!allow) {
                 throw new SecurityException();


### PR DESCRIPTION
Despite docs saying that OBB files are deprecated and that new apps are [forbidden from using them since August 2021](https://developer.android.com/google/play/expansion-files),
new popular games still come out that use them (eg Diablo, which was released in May 2022).
Also, there are several popular apps that use OBB files, prominent examples are Microsoft Office apps.

App that installs an OBB-using app is required to hold the WRITE_EXTERNAL_STORAGE permission despite the fact that access to just one directory is needed (Android/obb).

Use a special flag to control access to just Android/obb directory instead, without requiring a broad storage access permission.

Depends on:
https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/109
https://github.com/GrapheneOS/platform_packages_apps_GmsCompat/pull/22

Fully resolves https://github.com/GrapheneOS/os-issue-tracker/issues/821