### PR TITLE
CensoredNotif: Do not forward censored notification

### DIFF
--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -7170,6 +7170,13 @@ public class NotificationManagerService extends SystemService {
             return CensoredSendState.DONT_SEND;
         }
 
+        // Handles cases where the notification being sent is a censored notification itself.
+        if (SystemNotificationChannels.OTHER_USERS.equals(record.getChannel().getId())) {
+            if (DBG) Slog.d(TAG, "not sending censored notif due to original being " +
+                    "censored notification itself");
+            return CensoredSendState.DONT_SEND;
+        }
+
         // Handles reoccurring update notifications (fixes issues like status update spamming).
         if (record.isUpdate && (record.getNotification().flags & FLAG_ONLY_ALERT_ONCE) != 0) {
             if (DBG) Slog.d(TAG, "not sending censored notif due to original being " +


### PR DESCRIPTION
This handles cases where during a profile switch, a censored notification gets sent to user profile before the switch, then gets sent again to user profile being switched on.

Resolves https://github.com/GrapheneOS/os-issue-tracker/issues/1310