### PR TITLE
make special runtime permission infrastructure @SystemApi

### DIFF
--- a/core/api/system-current.txt
+++ b/core/api/system-current.txt
@@ -2945,6 +2945,14 @@ package android.content.pm {
     field @NonNull public static final android.os.Parcelable.Creator<android.content.pm.ShortcutManager.ShareShortcutInfo> CREATOR;
   }
 
+  public class SpecialRuntimePermAppUtils {
+    method public static boolean awareOfRuntimeInternetPermission();
+    method public static boolean isInternetCompatEnabled();
+    method public static boolean requestsInternetPermission();
+    field public static final int FLAG_AWARE_OF_RUNTIME_INTERNET_PERMISSION = 4; // 0x4
+    field public static final int FLAG_REQUESTS_INTERNET_PERMISSION = 2; // 0x2
+  }
+
   public final class SuspendDialogInfo implements android.os.Parcelable {
     method public int describeContents();
     method public void writeToParcel(android.os.Parcel, int);

--- a/core/java/android/app/ApplicationPackageManager.java
+++ b/core/java/android/app/ApplicationPackageManager.java
@@ -42,6 +42,7 @@ import android.content.IntentFilter;
 import android.content.IntentSender;
 import android.content.pm.ActivityInfo;
 import android.content.pm.ApkChecksum;
+import android.content.pm.AppPermissionUtils;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.ChangedPackages;
 import android.content.pm.Checksum;
@@ -123,7 +124,6 @@ import com.android.internal.annotations.Immutable;
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.internal.gmscompat.GmsInfo;
 import com.android.internal.os.SomeArgs;
-import com.android.internal.util.AppPermissionUtils;
 import com.android.internal.util.UserIcons;
 
 import dalvik.system.VMRuntime;

--- a/core/java/android/app/ContextImpl.java
+++ b/core/java/android/app/ContextImpl.java
@@ -46,6 +46,7 @@ import android.content.ReceiverCallNotAllowedException;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
+import android.content.pm.AppPermissionUtils;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.IPackageManager;
 import android.content.pm.PackageManager;
@@ -98,7 +99,6 @@ import com.android.internal.annotations.GuardedBy;
 import com.android.internal.gmscompat.BinderRedirector;
 import com.android.internal.gmscompat.sysservice.GmcPackageManager;
 import com.android.internal.gmscompat.GmsHooks;
-import com.android.internal.util.AppPermissionUtils;
 import com.android.internal.util.Preconditions;
 
 import dalvik.system.BlockGuard;

--- a/core/java/android/app/DownloadManager.java
+++ b/core/java/android/app/DownloadManager.java
@@ -55,7 +55,7 @@ import android.util.LongSparseArray;
 import android.util.Pair;
 import android.webkit.MimeTypeMap;
 
-import com.android.internal.util.SpecialRuntimePermAppUtils;
+import android.content.pm.SpecialRuntimePermAppUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/core/java/android/content/pm/AppPermissionUtils.java
+++ b/core/java/android/content/pm/AppPermissionUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.android.internal.util;
+package android.content.pm;
 
 import android.Manifest;
 
@@ -22,6 +22,7 @@ import com.android.internal.app.StorageScopesAppHooks;
 
 import static android.content.pm.GosPackageState.*;
 
+/** @hide */
 public class AppPermissionUtils {
 
     // android.app.ApplicationPackageManager#checkPermission(String permName, String pkgName)

--- a/core/java/android/content/pm/GosPackageState.java
+++ b/core/java/android/content/pm/GosPackageState.java
@@ -29,8 +29,6 @@ import android.os.RemoteException;
 import android.os.UserHandle;
 import android.permission.PermissionManager;
 
-import com.android.internal.util.AppPermissionUtils;
-
 /**
  * @hide
  */

--- a/core/java/com/android/internal/app/StorageScopesAppHooks.java
+++ b/core/java/com/android/internal/app/StorageScopesAppHooks.java
@@ -22,14 +22,13 @@ import android.app.AppGlobals;
 import android.app.AppOpsManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.AppPermissionUtils;
 import android.content.pm.GosPackageState;
 import android.net.Uri;
 import android.os.Environment;
 import android.os.Process;
 import android.provider.MediaStore;
 import android.provider.Settings;
-
-import com.android.internal.util.AppPermissionUtils;
 
 import static android.content.pm.GosPackageState.*;
 

--- a/services/core/java/com/android/server/pm/permission/SpecialRuntimePermUtils.java
+++ b/services/core/java/com/android/server/pm/permission/SpecialRuntimePermUtils.java
@@ -23,7 +23,7 @@ import android.os.Bundle;
 import com.android.internal.annotations.GuardedBy;
 import com.android.server.pm.parsing.pkg.AndroidPackage;
 
-import static com.android.internal.util.SpecialRuntimePermAppUtils.*;
+import static android.content.pm.SpecialRuntimePermAppUtils.*;
 
 public class SpecialRuntimePermUtils {
 


### PR DESCRIPTION
Needed to make it accessible from ConnectivityManager (contained in an APEX module).

Also fixes a bug in SpecialRuntimePermAppUtils#hasInternetPermission():
checkSelfPermission() results can be spoofed, which led to a false-positive return value.