### PR TITLE
Immediately put into effect always on vpn on first connection

### DIFF
--- a/services/core/java/com/android/server/VpnManagerService.java
+++ b/services/core/java/com/android/server/VpnManagerService.java
@@ -940,6 +940,7 @@ public class VpnManagerService extends IVpnManager.Stub {
 
     private void enforceSettingsPermission() {
         enforceAnyPermissionOf(mContext,
+                android.Manifest.permission.CONTROL_ALWAYS_ON_VPN,
                 android.Manifest.permission.NETWORK_SETTINGS,
                 NetworkStack.PERMISSION_MAINLINE_NETWORK_STACK);
     }

--- a/services/core/java/com/android/server/connectivity/Vpn.java
+++ b/services/core/java/com/android/server/connectivity/Vpn.java
@@ -28,6 +28,7 @@ import static android.os.UserHandle.PER_USER_RANGE;
 
 import static com.android.internal.util.Preconditions.checkArgument;
 import static com.android.internal.util.Preconditions.checkNotNull;
+import static com.android.net.module.util.PermissionUtils.enforceAnyPermissionOf;
 
 import android.Manifest;
 import android.annotation.NonNull;
@@ -1828,8 +1829,10 @@ public class Vpn {
     }
 
     private void enforceSettingsPermission() {
-        mContext.enforceCallingOrSelfPermission(Manifest.permission.NETWORK_SETTINGS,
-                "Unauthorized Caller");
+        enforceAnyPermissionOf(mContext,
+                android.Manifest.permission.CONTROL_ALWAYS_ON_VPN,
+                android.Manifest.permission.NETWORK_SETTINGS,
+                "Unathorized Caller");
     }
 
     private class Connection implements ServiceConnection {


### PR DESCRIPTION
Don't require reboot or settings re-set for always on and lockdown to take effect on first vpn connection.

Requires https://github.com/GrapheneOS/platform_packages_modules_Connectivity/pull/10