### PR TITLE
add an option to show the details of an application error to the user; + gmscompat

### DIFF
--- a/apex/jobscheduler/framework/java/android/os/PowerExemptionManager.java
+++ b/apex/jobscheduler/framework/java/android/os/PowerExemptionManager.java
@@ -30,7 +30,10 @@ import android.annotation.RequiresPermission;
 import android.annotation.SystemApi;
 import android.annotation.SystemService;
 import android.annotation.UserHandleAware;
+import android.app.compat.gms.GmsCompat;
 import android.content.Context;
+
+import com.android.internal.gmscompat.client.ClientPriorityManager;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -525,6 +528,11 @@ public class PowerExemptionManager {
     @RequiresPermission(android.Manifest.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST)
     public void addToTemporaryAllowList(@NonNull String packageName, @ReasonCode int reasonCode,
             @Nullable String reason, long durationMs) {
+        if (GmsCompat.isEnabled()) {
+            ClientPriorityManager.raiseToForeground(packageName, durationMs, reason, reasonCode);
+            return;
+        }
+
         try {
             mService.addPowerSaveTempWhitelistApp(packageName, durationMs, mContext.getUserId(),
                     reasonCode, reason);

--- a/cmds/app_process/app_main.cpp
+++ b/cmds/app_process/app_main.cpp
@@ -85,8 +85,10 @@ public:
         AndroidRuntime* ar = AndroidRuntime::getRuntime();
         ar->callMain(mClassName, mClass, mArgs);
 
-        IPCThreadState::self()->stopProcess();
-        hardware::IPCThreadState::self()->stopProcess();
+        if (mClassName != "com.android.internal.os.ExecInit") {
+            IPCThreadState::self()->stopProcess();
+            hardware::IPCThreadState::self()->stopProcess();
+        }
     }
 
     virtual void onZygoteInit()

--- a/core/java/android/app/WallpaperManager.java
+++ b/core/java/android/app/WallpaperManager.java
@@ -75,6 +75,7 @@ import android.view.Display;
 import android.view.WindowManagerGlobal;
 
 import com.android.internal.R;
+import com.android.internal.app.StorageScopesAppHooks;
 
 import libcore.io.IoUtils;
 
@@ -782,6 +783,10 @@ public class WallpaperManager {
      */
     @RequiresPermission(android.Manifest.permission.READ_EXTERNAL_STORAGE)
     public Drawable getDrawable() {
+        if (StorageScopesAppHooks.shouldSpoofSelfPermissionCheck(android.Manifest.permission.READ_EXTERNAL_STORAGE)) {
+            return null;
+        }
+
         final ColorManagementProxy cmProxy = getColorManagementProxy();
         Bitmap bm = sGlobals.peekWallpaperBitmap(mContext, true, FLAG_SYSTEM, cmProxy);
         if (bm != null) {
@@ -1039,6 +1044,10 @@ public class WallpaperManager {
      */
     @RequiresPermission(android.Manifest.permission.READ_EXTERNAL_STORAGE)
     public Drawable getFastDrawable() {
+        if (StorageScopesAppHooks.shouldSpoofSelfPermissionCheck(android.Manifest.permission.READ_EXTERNAL_STORAGE)) {
+            return null;
+        }
+
         final ColorManagementProxy cmProxy = getColorManagementProxy();
         Bitmap bm = sGlobals.peekWallpaperBitmap(mContext, true, FLAG_SYSTEM, cmProxy);
         if (bm != null) {
@@ -1056,6 +1065,10 @@ public class WallpaperManager {
      */
     @RequiresPermission(android.Manifest.permission.READ_EXTERNAL_STORAGE)
     public Drawable peekFastDrawable() {
+        if (StorageScopesAppHooks.shouldSpoofSelfPermissionCheck(android.Manifest.permission.READ_EXTERNAL_STORAGE)) {
+            return null;
+        }
+
         final ColorManagementProxy cmProxy = getColorManagementProxy();
         Bitmap bm = sGlobals.peekWallpaperBitmap(mContext, false, FLAG_SYSTEM, cmProxy);
         if (bm != null) {
@@ -1152,6 +1165,10 @@ public class WallpaperManager {
      */
     @RequiresPermission(android.Manifest.permission.READ_EXTERNAL_STORAGE)
     public ParcelFileDescriptor getWallpaperFile(@SetWallpaperFlags int which) {
+        if (StorageScopesAppHooks.shouldSpoofSelfPermissionCheck(android.Manifest.permission.READ_EXTERNAL_STORAGE)) {
+            return null;
+        }
+
         return getWallpaperFile(which, mContext.getUserId());
     }
 

--- a/core/java/android/content/pm/PackageInstaller.java
+++ b/core/java/android/content/pm/PackageInstaller.java
@@ -1334,8 +1334,17 @@ public class PackageInstaller {
          */
         public void commit(@NonNull IntentSender statusReceiver) {
             if (GmsCompat.isPlayStore()) {
-                statusReceiver = PlayStoreHooks.commitSession(statusReceiver);
+                statusReceiver = PlayStoreHooks.commitSession(this, statusReceiver);
+                if (statusReceiver == null) {
+                    return;
+                }
             }
+
+            commitInner(statusReceiver);
+        }
+
+        /** @hide */
+        public void commitInner(@NonNull IntentSender statusReceiver) {
             try {
                 mSession.commit(statusReceiver, false);
             } catch (RemoteException e) {

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2928,6 +2928,10 @@ public final class Settings {
                                 && application.getApplicationInfo().targetSdkVersion
                                 <= maxTargetSdk;
                         if (!targetSdkCheckOk) {
+                            if (GmsCompat.isEnabled()) {
+                                return null;
+                            }
+
                             throw new SecurityException(
                                     "Settings key: <" + name + "> is only readable to apps with "
                                             + "targetSdkVersion lower than or equal to: "

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -433,14 +433,8 @@ public final class GmsHooks {
             return options;
         }
 
-        if (!targetPkg.equals(GmsInfo.PACKAGE_GMS_CORE)) {
-            Log.d(TAG, "emulating temporary PowerExemptionManager allowlist for " + targetPkg
-                + ", duration: " + duration
-                + ", reason: " + bo.getTemporaryAppAllowlistReason()
-                + ", reasonCode: " + PowerExemptionManager.reasonCodeToString(bo.getTemporaryAppAllowlistReasonCode()));
-
-            ClientPriorityManager.raiseToForeground(targetPkg, duration);
-        }
+        ClientPriorityManager.raiseToForeground(targetPkg, duration,
+                bo.getTemporaryAppAllowlistReason(), bo.getTemporaryAppAllowlistReasonCode());
 
         bo.setTemporaryAppAllowlist(0, PowerExemptionManager.TEMPORARY_ALLOW_LIST_TYPE_NONE,
                 PowerExemptionManager.REASON_UNKNOWN, null);

--- a/core/java/com/android/internal/gmscompat/client/ClientPriorityManager.java
+++ b/core/java/com/android/internal/gmscompat/client/ClientPriorityManager.java
@@ -16,13 +16,17 @@
 
 package com.android.internal.gmscompat.client;
 
+import android.annotation.Nullable;
 import android.app.compat.gms.GmsCompat;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
+import android.os.PowerExemptionManager;
 import android.util.Log;
+
+import com.android.internal.gmscompat.GmsInfo;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -38,6 +42,24 @@ public class ClientPriorityManager implements ServiceConnection, Runnable {
     private boolean unbound;
 
     private ClientPriorityManager() {}
+
+    public static void raiseToForeground(String targetPkg, long durationMs, @Nullable String reason, int reasonCode) {
+        if (durationMs <= 0) {
+            return;
+        }
+
+        if (targetPkg.equals(GmsInfo.PACKAGE_GMS_CORE)) {
+            // always foreground, and doesn't have the GmsCompatClientService
+            return;
+        }
+
+        Log.d(TAG, "emulating temporary PowerExemptionManager allowlist for " + targetPkg
+            + ", duration: " + durationMs
+            + ", reason: " + reason
+            + ", reasonCode: " + PowerExemptionManager.reasonCodeToString(reasonCode));
+
+        raiseToForeground(targetPkg, durationMs);
+    }
 
     public static void raiseToForeground(String targetPkg, long durationMs) {
         Intent intent = new Intent();

--- a/core/java/com/android/internal/gmscompat/sysservice/GmcTelephonyManager.java
+++ b/core/java/com/android/internal/gmscompat/sysservice/GmcTelephonyManager.java
@@ -151,4 +151,14 @@ public class GmcTelephonyManager extends TelephonyManager {
             return TelephonyManager.CALL_STATE_IDLE;
         }
     }
+
+    @Override
+    public int getVoiceNetworkType() {
+        try {
+            return super.getVoiceNetworkType();
+        } catch (SecurityException e) { // missing READ_PHONE_STATE permission
+            Log.d(TAG, "", e);
+            return NETWORK_TYPE_UNKNOWN;
+        }
+    }
 }

--- a/core/res/res/layout/app_anr_dialog.xml
+++ b/core/res/res/layout/app_anr_dialog.xml
@@ -41,8 +41,8 @@
             android:id="@+id/aerr_report"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/aerr_report"
-            android:drawableStart="@drawable/ic_feedback"
+            android:text="@string/aerr_show_details"
+            android:drawableStart="@drawable/ic_info_outline_24"
             style="@style/aerr_list_item" />
 
 </LinearLayout>

--- a/core/res/res/layout/app_error_dialog.xml
+++ b/core/res/res/layout/app_error_dialog.xml
@@ -52,8 +52,8 @@
         android:id="@+id/aerr_report"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/aerr_report"
-        android:drawableStart="@drawable/ic_feedback"
+        android:text="@string/aerr_show_details"
+        android:drawableStart="@drawable/ic_info_outline_24"
         style="@style/aerr_list_item" />
 
     <Button

--- a/core/res/res/values/strings.xml
+++ b/core/res/res/values/strings.xml
@@ -6082,4 +6082,7 @@ ul.</string>
     <string name="notification_channel_other_users_description">Censored notifications from the lock screens of other users</string>
     <string name="other_users_notification_title">Notification from <xliff:g id="app_name" example="Messages">%1$s</xliff:g> for <xliff:g id="username" example="Alice">%2$s</xliff:g></string>
     <string name="other_users_notification_switch_user_action">Switch to <xliff:g id="username" example="Bob">%1$s</xliff:g></string>
+
+    <!-- Button that opens the screen with details of an application error -->
+    <string name="aerr_show_details">Show details</string>
 </resources>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -4506,4 +4506,7 @@
   <java-symbol type="string" name="notification_channel_other_users_description" />
   <java-symbol type="string" name="other_users_notification_title" />
   <java-symbol type="string" name="other_users_notification_switch_user_action" />
+
+  <!-- Button that opens the screen with details of an application error -->
+  <java-symbol type="string" name="aerr_show_details" />
 </resources>

--- a/packages/SystemUI/AndroidManifest.xml
+++ b/packages/SystemUI/AndroidManifest.xml
@@ -866,5 +866,17 @@
             </intent-filter>
         </receiver>
 
+        <activity
+            android:name=".ErrorReportActivity"
+            android:exported="true"
+            android:theme="@android:style/Theme.DeviceDefault.DayNight"
+            android:documentLaunchMode="always"
+            android:process=":ui"
+        >
+            <intent-filter>
+                <action android:name="android.intent.action.APP_ERROR" />
+            </intent-filter>
+        </activity>
+
     </application>
 </manifest>

--- a/packages/SystemUI/res/values/strings.xml
+++ b/packages/SystemUI/res/values/strings.xml
@@ -2354,4 +2354,9 @@
 
     <!-- Title for User Switch dialog. [CHAR LIMIT=20] -->
     <string name="qs_user_switch_dialog_title">Select user</string>
+
+    <string name="error_report_title">Error in %1$s</string>
+    <string name="copy_to_clipboard">Copy to clipboard</string>
+    <string name="copied_to_clipboard">Copied to clipboard</string>
+    <string name="error_share">Share</string>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/ErrorReportActivity.kt
+++ b/packages/SystemUI/src/com/android/systemui/ErrorReportActivity.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2022 GrapheneOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui
+
+import android.app.Activity
+import android.app.ApplicationErrorReport
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.ClipboardManager
+import android.content.Intent
+import android.graphics.Typeface
+import android.os.Build
+import android.os.Bundle
+import android.util.StringBuilderPrinter
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.LinearLayout.LayoutParams
+import android.widget.ScrollView
+import android.widget.TextView
+import android.widget.Toast
+
+class ErrorReportActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val title: String
+        val reportText: String
+        try {
+            val report = intent.getParcelableExtra<ApplicationErrorReport>(Intent.EXTRA_BUG_REPORT)!!
+            val pm = packageManager
+            val ai = pm.getApplicationInfo(report.packageName, 0)
+            title = getString(R.string.error_report_title, ai.loadLabel(pm))
+
+            reportText = errorReportToText(report)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            finishAndRemoveTask()
+            return
+        }
+
+        setTitle(title)
+
+        val textView = TextView(this).apply {
+            typeface = Typeface.MONOSPACE
+            text = reportText
+            textSize = 12f
+            setTextIsSelectable(true)
+            // default color is too light
+            val color = if (resources.configuration.isNightModeActive) 0xff_d0_d0_d0 else 0xff_00_00_00
+            setTextColor(color.toInt())
+        }
+
+        val scroller = ScrollView(this).apply {
+            isScrollbarFadingEnabled = false
+            scrollBarStyle = View.SCROLLBARS_INSIDE_INSET
+            addView(textView)
+        }
+
+        val formattedReportText = "```\n" + reportText + "\n```"
+        val clipData = ClipData.newPlainText(title, formattedReportText)
+
+        val btnCopy = Button(this).apply {
+            setText(R.string.copy_to_clipboard)
+            setOnClickListener { _ ->
+                val cm = getSystemService(ClipboardManager::class.java)
+                cm.setPrimaryClip(clipData)
+                Toast.makeText(this@ErrorReportActivity, R.string.copied_to_clipboard, Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        val btnShare = Button(this).apply {
+            setText(R.string.error_share)
+            setOnClickListener { _ ->
+                val i = Intent(Intent.ACTION_SEND)
+                i.clipData = clipData
+                i.type = ClipDescription.MIMETYPE_TEXT_PLAIN
+                i.putExtra(Intent.EXTRA_SUBJECT, title)
+                i.putExtra(Intent.EXTRA_TEXT, formattedReportText)
+                startActivity(Intent.createChooser(i, title))
+            }
+        }
+
+        val buttonLayout = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+            addView(btnCopy)
+            addView(btnShare)
+        }
+
+        val pad = px(16)
+
+        val layout = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            addView(scroller, LayoutParams(LayoutParams.MATCH_PARENT, 0, 1f))
+            addView(buttonLayout)
+            setPadding(pad, pad, pad, pad)
+        }
+
+        setContentView(layout)
+    }
+
+    fun px(dp: Int) = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_PX, dp.toFloat(), resources.displayMetrics).toInt()
+
+    fun errorReportToText(r: ApplicationErrorReport) =
+
+"""type: ${reportTypeToString(r.type)}
+osVersion: ${Build.FINGERPRINT}
+package: ${r.packageName}:${r.packageVersion}
+process: ${r.processName}
+
+${reportInfoToString(r)}"""
+
+    fun reportInfoToString(r: ApplicationErrorReport): String {
+        if (r.type == ApplicationErrorReport.TYPE_CRASH) {
+            return r.crashInfo.stackTrace
+        }
+
+        val sb = StringBuilder()
+        val printer = StringBuilderPrinter(sb)
+
+        when (r.type) {
+            ApplicationErrorReport.TYPE_ANR ->
+                r.anrInfo.dump(printer, "")
+            ApplicationErrorReport.TYPE_BATTERY ->
+                r.batteryInfo.dump(printer, "")
+            ApplicationErrorReport.TYPE_RUNNING_SERVICE ->
+                r.runningServiceInfo.dump(printer, "")
+        }
+
+        return sb.toString()
+    }
+
+    fun reportTypeToString(type: Int) = when (type) {
+        ApplicationErrorReport.TYPE_CRASH -> "crash"
+        ApplicationErrorReport.TYPE_ANR -> "ANR"
+        ApplicationErrorReport.TYPE_BATTERY -> "battery"
+        ApplicationErrorReport.TYPE_RUNNING_SERVICE -> "running_service"
+        else -> "unknown ($type)"
+    }
+}

--- a/services/core/java/com/android/server/am/AppErrors.java
+++ b/services/core/java/com/android/server/am/AppErrors.java
@@ -814,6 +814,7 @@ class AppErrors {
 
         ApplicationErrorReport report = new ApplicationErrorReport();
         report.packageName = r.info.packageName;
+        report.packageVersion = r.info.longVersionCode;
         report.installerPackageName = errState.getErrorReportReceiver().getPackageName();
         report.processName = r.processName;
         report.time = timeMillis;


### PR DESCRIPTION
Depends on https://github.com/GrapheneOS/platform_packages_apps_GmsCompat/pull/23

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/1130 (Google Chrome and its variants are the only known users of multi package sessions, not counting their WebView counterparts which are useless on GrapheneOS but are supported too).

Partially addresses https://github.com/GrapheneOS/os-issue-tracker/issues/1064