### PR TITLE
fix DevicePolicyManager#logoutUser() never succeeding

### DIFF
--- a/services/devicepolicy/java/com/android/server/devicepolicy/DevicePolicyManagerService.java
+++ b/services/devicepolicy/java/com/android/server/devicepolicy/DevicePolicyManagerService.java
@@ -11128,6 +11128,12 @@ public class DevicePolicyManagerService extends BaseIDevicePolicyManager {
         Preconditions.checkCallAuthorization(canManageUsers(caller)
                 || hasCallingOrSelfPermission(permission.INTERACT_ACROSS_USERS));
 
+        synchronized (getLockObject()) {
+            if (getLogoutUserIdUnchecked() == UserHandle.USER_NULL) {
+                setLogoutUserIdLocked(UserHandle.USER_SYSTEM);
+            }
+        }
+
         int currentUserId = getCurrentForegroundUserId();
         if (VERBOSE_LOG) {
             Slogf.v(LOG_TAG, "logout() called by uid %d; current user is %d", caller.getUid(),


### PR DESCRIPTION
To succeed, userId to switch to needs to be set with setLogoutUserIdLocked(), but this is not done
in both callers of this method (both of which are "End session" buttons), making them no-ops.