### PR TITLE
gosps: allow system Launcher to access GosPackageState

### DIFF
--- a/services/core/java/com/android/server/pm/GosPackageStatePmHooks.java
+++ b/services/core/java/com/android/server/pm/GosPackageStatePmHooks.java
@@ -111,7 +111,9 @@ class GosPackageStatePmHooks {
                     allow = selfCheck
                             || callingAppId == pm.mediaProviderAppId
                             || callingAppId == pm.permissionControllerAppId
-                            || callingAppId == Process.SYSTEM_UID;
+                            || callingAppId == Process.SYSTEM_UID
+                            || callingAppId == pm.sysLauncherAppId
+                    ;
                 }
                 if (!allow) {
                     throw new SecurityException();

--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -7289,6 +7289,7 @@ public class PackageManagerService implements PackageSender, TestUtilityService 
 
     int mediaProviderAppId;
     int permissionControllerAppId;
+    int sysLauncherAppId;
 
     private void initGosPackageStateAppIds() {
         synchronized (mLock) {
@@ -7301,6 +7302,11 @@ public class PackageManagerService implements PackageSender, TestUtilityService 
             AndroidPackage permissionController = mPackages.get(mRequiredPermissionControllerPackage);
             if (permissionController != null) {
                 permissionControllerAppId = permissionController.getUid();
+            }
+
+            var sysLauncher = mPackages.get("com.android.launcher3");
+            if (sysLauncher != null) {
+                sysLauncherAppId = sysLauncher.getUid();
             }
         }
     }


### PR DESCRIPTION
Needed for adding Storage Scopes link only to those apps that have it enabled.
