### PR TITLE
skip "Exploit protection compatibility mode" after explicit UID kill

### DIFF
--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -7793,6 +7793,9 @@ public class ActivityManagerService extends IActivityManager.Stub
     @Override
     public void killUid(int appId, int userId, String reason) {
         enforceCallingPermission(Manifest.permission.KILL_UID, "killUid");
+
+        RelaxAppHardeningNotification.onUserRequestedAppKill();
+
         synchronized (this) {
             final long identity = Binder.clearCallingIdentity();
             try {


### PR DESCRIPTION
killUid() is sometimes called when the app is in the foreground, which would trigger this
notification.
