### PR TITLE
srt permissions: don't auto-revoke from "hidden" packages

### DIFF
--- a/services/core/java/com/android/server/pm/permission/PermissionManagerServiceImpl.java
+++ b/services/core/java/com/android/server/pm/permission/PermissionManagerServiceImpl.java
@@ -2610,7 +2610,7 @@ public class PermissionManagerServiceImpl implements PermissionManagerServiceInt
         synchronized (mLock) {
             for (final int userId : userIds) {
                 final boolean isNotInstalledUserApp = !ps.isSystem()
-                        && !PackageUserStateUtils.isAvailable(ps.getUserStateOrDefault(userId), 0);
+                        && !ps.getUserStateOrDefault(userId).isInstalled();
 
                 final UserPermissionState userState = mState.getOrCreateUserState(userId);
                 final UidPermissionState uidState = userState.getOrCreateUidState(ps.getAppId());


### PR DESCRIPTION
Special runtime permissions are auto-revoked in users that don't have the package installed, as a
workaround to a bug in previous OS versions that granted these permissions automatically in all
user profiles, including the ones that don't have this package installed, which interfered with
configurable auto-grants.

PackageUserStateUtils.isAvailable() is not the right check for this, it returns false for apps
which are "hidden" with DevicePolicyManager#setApplicationHidden(). This method is used by work
profile managers (in particular, Shelter) to implement "app freezing" functionality.

This led to special runtime permission being auto-revoked from "hidden" packages after OS reboot
and in a few other cases.
