### PR TITLE
extend original-package renaming to provider authorities for Vanadium

### DIFF
--- a/services/core/java/com/android/server/pm/parsing/pkg/PackageImpl.java
+++ b/services/core/java/com/android/server/pm/parsing/pkg/PackageImpl.java
@@ -333,9 +333,46 @@ public class PackageImpl extends ParsingPackageImpl implements ParsedPackage, An
             ComponentMutateUtils.setPackageName(receivers.get(index), this.packageName);
         }
 
+        final String legacyVanadiumPkgName = "org.chromium.chrome";
+        final String realVanadiumPkgName = "app.vanadium.browser";
+
+        final boolean isLegacyVanadiumPkgName = legacyVanadiumPkgName.equals(packageName)
+                // original-package handling currently happens only for preinstalled apps,
+                // but double-check in case it's expanded to user apps in the future or if
+                // isSystem() check is performed after original-package handling instead of before it
+                && isSystem();
+
+        if (isLegacyVanadiumPkgName) {
+            if (!getManifestPackageName().equals(realVanadiumPkgName)) {
+                throw new IllegalStateException("unexpected manifestPackageName: " +
+                        "expected " + realVanadiumPkgName + ", got " + getManifestPackageName());
+            }
+        }
+
         int providersSize = providers.size();
         for (int index = 0; index < providersSize; index++) {
-            ComponentMutateUtils.setPackageName(providers.get(index), this.packageName);
+            ParsedProvider provider = providers.get(index);
+            ComponentMutateUtils.setPackageName(provider, this.packageName);
+
+            if (isLegacyVanadiumPkgName) {
+                // method name "getAuthority" is misleading: it may return multiple
+                // ';'-separated authorities
+                final String separator = ";";
+                String[] authorities = provider.getAuthority().split(separator);
+
+                for (int i = 0; i < authorities.length; ++i) {
+                    String authority = authorities[i];
+                    if (!authority.startsWith(realVanadiumPkgName)) {
+                        // all Chromium ContentProvider authorities are prefixed with manifest package name
+                        throw new IllegalStateException("unexpected Vanadium ContentProvider authority " + authority);
+                    }
+
+                    authorities[i] = authority.replaceFirst(realVanadiumPkgName, legacyVanadiumPkgName);
+                }
+
+                String renamedAuthorities = String.join(separator, authorities);
+                ComponentMutateUtils.setAuthority(provider, renamedAuthorities);
+            }
         }
 
         int servicesSize = services.size();


### PR DESCRIPTION
In general case, ContentProvider authorities can't be renamed because they aren't required to be
based on the package name.

Chromium always forms ContentProvider authorities by prefixing them with its package name, and
relies on this invariant in code.

When its package is renamed by original-package handling code, statements like
`String authority = context.getPackageName() + CONSTANT`
become invalid.

Add a special-case for Vanadium to fix this.
