### PR TITLE
allow configuring notification for cell broadcast

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -3966,7 +3966,6 @@
     <string-array translatable="false" name="config_nonBlockableNotificationPackages">
         <item>com.android.dialer</item>
         <item>com.android.messaging</item>
-        <item>com.android.cellbroadcastreceiver.module</item>
     </string-array>
 
     <!-- An array of packages that can make sound on the ringer stream in priority-only DND


### PR DESCRIPTION
closes [#1759](https://github.com/GrapheneOS/os-issue-tracker/issues/1759)