### PR TITLE
Add app.grapheneos.apps to vendor_required_apps_managed_*

### DIFF
--- a/core/res/res/values/vendor_required_apps_managed_device.xml
+++ b/core/res/res/values/vendor_required_apps_managed_device.xml
@@ -20,5 +20,6 @@
     <!-- A list of apps to be retained on the managed device by a particular vendor.
             Takes precedence over the disallowed apps lists. -->
     <string-array translatable="false" name="vendor_required_apps_managed_device">
+        <item>app.grapheneos.apps</item>
     </string-array>
 </resources>

--- a/core/res/res/values/vendor_required_apps_managed_profile.xml
+++ b/core/res/res/values/vendor_required_apps_managed_profile.xml
@@ -20,5 +20,6 @@
     <!-- A list of apps to be retained in the managed profile by a particular vendor.
             Takes precedence over the disallowed apps lists. -->
     <string-array translatable="false" name="vendor_required_apps_managed_profile">
+        <item>app.grapheneos.apps</item>
     </string-array>
 </resources>

--- a/core/res/res/values/vendor_required_apps_managed_user.xml
+++ b/core/res/res/values/vendor_required_apps_managed_user.xml
@@ -20,5 +20,6 @@
     <!-- A list of apps to be retained on the managed user by a particular vendor.
             Takes precedence over the disallowed apps lists. -->
     <string-array translatable="false" name="vendor_required_apps_managed_user">
+        <item>app.grapheneos.apps</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Allow Apps being added in managed work profiles, devices, and users in the event the managed profile needs sandboxed Google Play

Signed-off-by: r3g_5z <june@girlboss.ceo>