### PR TITLE
bugfix: isServiceTokenValidLocked() was called without holding the lock

### DIFF
--- a/services/core/java/com/android/server/notification/ManagedServices.java
+++ b/services/core/java/com/android/server/notification/ManagedServices.java
@@ -1002,6 +1002,12 @@ abstract public class ManagedServices {
         return null;
     }
 
+    protected boolean isServiceTokenValid(IInterface service) {
+        synchronized (mMutex) {
+            return isServiceTokenValidLocked(service);
+        }
+    }
+
     protected boolean isServiceTokenValidLocked(IInterface service) {
         if (service == null) {
             return false;

--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -10390,7 +10390,7 @@ public class NotificationManagerService extends SystemService {
      * given NAS is bound in.
      */
     private boolean isInteractionVisibleToListener(ManagedServiceInfo info, int userId) {
-        boolean isAssistantService = mAssistants.isServiceTokenValidLocked(info.service);
+        boolean isAssistantService = mAssistants.isServiceTokenValid(info.service);
         return !isAssistantService || info.isSameUser(userId);
     }
 
@@ -11651,7 +11651,7 @@ public class NotificationManagerService extends SystemService {
                 BackgroundThread.getHandler().post(() -> {
                     if (info.isSystem
                             || hasCompanionDevice(info)
-                            || mAssistants.isServiceTokenValidLocked(info.service)) {
+                            || mAssistants.isServiceTokenValid(info.service)) {
                         notifyNotificationChannelChanged(
                                 info, pkg, user, channel, modificationType);
                     }


### PR DESCRIPTION
This method iterates through a list that is modified by multiple threads, which is not safe to do without locking.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/1899