### PR TITLE
Disable instant apps feature and settings, with adding users at lock screen every boot

### DIFF
--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
@@ -2919,6 +2919,7 @@ public class SettingsProvider extends ContentProvider {
             // Upgrade the settings to the latest version.
             UpgradeController upgrader = new UpgradeController(userId);
             upgrader.upgradeIfNeededLocked();
+            SettingsProviderHooks.onSettingsStateInit(SettingsRegistry.this, userId);
             return true;
         }
 

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProviderHooks.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProviderHooks.java
@@ -9,6 +9,7 @@ class SettingsProviderHooks {
         if (userId == UserHandle.USER_SYSTEM) {
             SettingsState globalSettings = registry.getSettingsLocked(SettingsProvider.SETTINGS_TYPE_GLOBAL, userId);
             insertSetting(globalSettings, Settings.Global.ADD_USERS_WHEN_LOCKED, "0" /* disabled value */);
+            insertSetting(globalSettings, Settings.Global.ENABLE_EPHEMERAL_FEATURE, "0" /* disabled value */);
         }
         SettingsState secureSettings = registry.getSettingsLocked(SettingsProvider.SETTINGS_TYPE_SECURE, userId);
     }

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProviderHooks.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProviderHooks.java
@@ -1,0 +1,22 @@
+package com.android.providers.settings;
+
+import android.os.UserHandle;
+import android.provider.Settings;
+
+class SettingsProviderHooks {
+
+    static void onSettingsStateInit(final SettingsProvider.SettingsRegistry registry, final int userId) {
+        if (userId == UserHandle.USER_SYSTEM) {
+            SettingsState globalSettings = registry.getSettingsLocked(SettingsProvider.SETTINGS_TYPE_GLOBAL, userId);
+        }
+        SettingsState secureSettings = registry.getSettingsLocked(SettingsProvider.SETTINGS_TYPE_SECURE, userId);
+    }
+
+    /**
+     * Unlike UpgradeController#upgradeIfNeededLocked settings migration, this runs every time a user is initialized.
+     * Insert or modify setting upon SettingState initialization for any user, or in case of system user, upon boot.
+     */
+    private static void insertSetting(SettingsState state, String key, String value) {
+        state.insertSettingLocked(key, value, null /* tag */, false /* makeDefault */, SettingsState.SYSTEM_PACKAGE_NAME);
+    }
+}

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProviderHooks.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProviderHooks.java
@@ -8,6 +8,7 @@ class SettingsProviderHooks {
     static void onSettingsStateInit(final SettingsProvider.SettingsRegistry registry, final int userId) {
         if (userId == UserHandle.USER_SYSTEM) {
             SettingsState globalSettings = registry.getSettingsLocked(SettingsProvider.SETTINGS_TYPE_GLOBAL, userId);
+            insertSetting(globalSettings, Settings.Global.ADD_USERS_WHEN_LOCKED, "0" /* disabled value */);
         }
         SettingsState secureSettings = registry.getSettingsLocked(SettingsProvider.SETTINGS_TYPE_SECURE, userId);
     }


### PR DESCRIPTION
Merge with https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/140 for completeness, that is, to hide the now no-op Settings that toggle the moved settings