### PR TITLE
Allow setting and unsetting current backup app when enabled or disabled

### DIFF
--- a/services/backup/backuplib/java/com/android/server/backup/TransportManager.java
+++ b/services/backup/backuplib/java/com/android/server/backup/TransportManager.java
@@ -159,6 +159,10 @@ public class TransportManager {
                 return;
             }
             switch (enabled) {
+                case PackageManager.COMPONENT_ENABLED_STATE_DEFAULT:
+                    if (!"com.stevesoltys.seedvault".equals(packageName)) {
+                        return;
+                    }
                 case COMPONENT_ENABLED_STATE_ENABLED: {
                     if (MORE_DEBUG) {
                         Slog.d(TAG, "Package " + packageName + " was enabled.");
@@ -166,6 +170,10 @@ public class TransportManager {
                     onPackageEnabled(packageName);
                     return;
                 }
+                case PackageManager.COMPONENT_ENABLED_STATE_DISABLED_USER:
+                    if (!"com.stevesoltys.seedvault".equals(packageName)) {
+                        return;
+                    }
                 case COMPONENT_ENABLED_STATE_DISABLED: {
                     if (MORE_DEBUG) {
                         Slog.d(TAG, "Package " + packageName + " was disabled.");


### PR DESCRIPTION
This allows to properly set and unset backup transport whenever the current backup app, in this case, Seedvault, is disabled by adb or by Settings, exposed at https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/141  