### PR TITLE
improve support for per-user settings in setting helper classes

### DIFF
--- a/core/java/android/ext/settings/BoolSetting.java
+++ b/core/java/android/ext/settings/BoolSetting.java
@@ -6,13 +6,11 @@
 package android.ext.settings;
 
 import android.content.Context;
-import android.os.Handler;
 
 import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
 
 /** @hide */
-public class BoolSetting extends Setting {
+public class BoolSetting extends Setting<BoolSetting> {
     private boolean defaultValue;
     private volatile BooleanSupplier defaultValueSupplier;
 
@@ -27,7 +25,12 @@ public class BoolSetting extends Setting {
     }
 
     public final boolean get(Context ctx) {
-        String valueStr = getRaw(ctx);
+        return get(ctx, ctx.getUserId());
+    }
+
+    // use only if this is a per-user setting and the context is not a per-user one
+    public final boolean get(Context ctx, int userId) {
+        String valueStr = getRaw(ctx, userId);
 
         if (valueStr == null) {
             return getDefaultValue();
@@ -49,10 +52,6 @@ public class BoolSetting extends Setting {
 
     public final boolean put(Context ctx, boolean val) {
         return putRaw(ctx, val ? "1" : "0");
-    }
-
-    public final Object registerObserver(Context ctx, Consumer<BoolSetting> callback, Handler handler) {
-        return registerObserverInner(ctx, callback, handler);
     }
 
     private boolean getDefaultValue() {

--- a/core/java/android/ext/settings/IntSetting.java
+++ b/core/java/android/ext/settings/IntSetting.java
@@ -7,13 +7,11 @@ package android.ext.settings;
 
 import android.annotation.Nullable;
 import android.content.Context;
-import android.os.Handler;
 
-import java.util.function.Consumer;
 import java.util.function.IntSupplier;
 
 /** @hide */
-public class IntSetting extends Setting {
+public class IntSetting extends Setting<IntSetting> {
     private int defaultValue;
     private volatile IntSupplier defaultValueSupplier;
 
@@ -58,7 +56,12 @@ public class IntSetting extends Setting {
     }
 
     public final int get(Context ctx) {
-        String valueStr = getRaw(ctx);
+        return get(ctx, ctx.getUserId());
+    }
+
+    // use only if this is a per-user setting and the context is not a per-user one
+    public final int get(Context ctx, int userId) {
+        String valueStr = getRaw(ctx, userId);
 
         if (valueStr == null) {
             return getDefaultValue();
@@ -84,10 +87,6 @@ public class IntSetting extends Setting {
             throw new IllegalArgumentException(Integer.toString(val));
         }
         return putRaw(ctx, Integer.toString(val));
-    }
-
-    public final Object registerObserver(Context ctx, Consumer<IntSetting> callback, Handler handler) {
-        return registerObserverInner(ctx, callback, handler);
     }
 
     private void setDefaultValue(int val) {

--- a/core/java/android/ext/settings/StringSetting.java
+++ b/core/java/android/ext/settings/StringSetting.java
@@ -6,13 +6,11 @@
 package android.ext.settings;
 
 import android.content.Context;
-import android.os.Handler;
 
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /** @hide */
-public class StringSetting extends Setting {
+public class StringSetting extends Setting<StringSetting> {
     private String defaultValue;
     private volatile Supplier<String> defaultValueSupplier;
 
@@ -31,7 +29,12 @@ public class StringSetting extends Setting {
     }
 
     public final String get(Context ctx) {
-        String s = getRaw(ctx);
+        return get(ctx, ctx.getUserId());
+    }
+
+    // use only if this is a per-user setting and the context is not a per-user one
+    public final String get(Context ctx, int userId) {
+        String s = getRaw(ctx, userId);
         if (s == null || !validateValue(s)) {
             return getDefaultValue();
         }
@@ -43,10 +46,6 @@ public class StringSetting extends Setting {
             throw new IllegalStateException("invalid value " + val);
         }
         return putRaw(ctx, val);
-    }
-
-    public final Object registerObserver(Context ctx, Consumer<StringSetting> callback, Handler handler) {
-        return registerObserverInner(ctx, callback, handler);
     }
 
     private void setDefaultValue(String val) {

--- a/services/core/java/com/android/server/pm/permission/SpecialRuntimePermUtils.java
+++ b/services/core/java/com/android/server/pm/permission/SpecialRuntimePermUtils.java
@@ -69,8 +69,7 @@ public class SpecialRuntimePermUtils {
             // use parent profile settings for work profile
             int userIdForSettings = um.getProfileParentId(userId);
 
-            Context settingsCtx = ctx.createContextAsUser(UserHandle.of(userIdForSettings), 0);
-            return ExtSettings.AUTO_GRANT_OTHER_SENSORS_PERMISSION.get(settingsCtx);
+            return ExtSettings.AUTO_GRANT_OTHER_SENSORS_PERMISSION.get(ctx, userIdForSettings);
         }
 
         return !isAutoGrantSkipped(packageName, userId, perm);


### PR DESCRIPTION
- allow to retrieve the user-specific setting value and to lister for user-specific setting changes
 with any Context, not just the user-specific one
 - make registerObserver() a generic method to avoid duplicating it across setting value types