### PR TITLE
make settings defined in ExtSettings unreadable by third-party apps

### DIFF
--- a/core/java/android/ext/settings/ExtSettings.java
+++ b/core/java/android/ext/settings/ExtSettings.java
@@ -1,5 +1,8 @@
 package android.ext.settings;
 
+import java.lang.reflect.Field;
+import java.util.Set;
+
 /** @hide */
 public class ExtSettings {
 
@@ -16,4 +19,25 @@ public class ExtSettings {
             Setting.Scope.PER_USER, "screenshot_timestamp_exif", false);
 
     private ExtSettings() {}
+
+    // used for making settings defined in this class unreadable by third-party apps
+    public static void getKeys(Setting.Scope scope, Set<String> dest) {
+        for (Field field : ExtSettings.class.getDeclaredFields()) {
+            if (!Setting.class.isAssignableFrom(field.getType())) {
+                continue;
+            }
+            Setting s;
+            try {
+                s = (Setting) field.get(null);
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+
+            if (s.getScope() == scope) {
+                if (!dest.add(s.getKey())) {
+                    throw new IllegalStateException("duplicate definition of setting " + s.getKey());
+                }
+            }
+        }
+    }
 }

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -53,6 +53,8 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.database.SQLException;
+import android.ext.settings.ExtSettings;
+import android.ext.settings.Setting;
 import android.location.ILocationManager;
 import android.location.LocationManager;
 import android.media.AudioManager;
@@ -3541,6 +3543,17 @@ public final class Settings {
                         keysWithMaxTargetSdk.put(key, maxTargetSdk);
                     }
                 }
+            }
+
+            Setting.Scope extSettingsScope = null;
+            if (callerClass == Global.class) {
+                extSettingsScope = Setting.Scope.GLOBAL;
+            } else if (callerClass == Secure.class) {
+                extSettingsScope = Setting.Scope.PER_USER;
+            }
+
+            if (extSettingsScope != null) {
+                ExtSettings.getKeys(extSettingsScope, allKeys);
             }
         } catch (IllegalAccessException ignored) {
         }


### PR DESCRIPTION
Applies to Settings.{Global,Secure} settings. System properties don't have this kind of access checks.