### PR TITLE
allow privileged installers to maintain a global list of busy packages

### DIFF
--- a/core/java/android/app/ApplicationPackageManager.java
+++ b/core/java/android/app/ApplicationPackageManager.java
@@ -3868,4 +3868,16 @@ public class ApplicationPackageManager extends PackageManager {
             throw e.rethrowAsRuntimeException();
         }
     }
+
+    @UnsupportedAppUsage
+    public boolean updateListOfBusyPackages(boolean locked, List<String> packageNames) {
+        // used for automatically removing packages after our process dies
+        android.os.Binder callerBinder = ActivityThread.currentActivityThread().getApplicationThread();
+
+        try {
+            return mPM.updateListOfBusyPackages(locked, packageNames, callerBinder);
+        } catch (RemoteException e) {
+            throw e.rethrowFromSystemServer();
+        }
+    }
 }

--- a/core/java/android/content/pm/IPackageManager.aidl
+++ b/core/java/android/content/pm/IPackageManager.aidl
@@ -813,4 +813,6 @@ interface IPackageManager {
     void skipSpecialRuntimePermissionAutoGrantsForPackage(String packageName, int userId, in List<String> permissions);
 
     PackageInfo findPackage(String packageName, long minVersion, in Bundle validSignaturesSha256);
+
+    boolean updateListOfBusyPackages(boolean add, in List<String> packageNames, IBinder callerBinder);
 }

--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -6093,6 +6093,14 @@ public class PackageManagerService implements PackageSender, TestUtilityService 
             }
             return pi;
         }
+
+        private final PrivilegedInstallerHelper privInstallerHelper =
+                new PrivilegedInstallerHelper(PackageManagerService.this);
+
+        @Override
+        public boolean updateListOfBusyPackages(boolean add, List<String> packageNames, IBinder callerBinder) {
+            return privInstallerHelper.updateListOfBusyPackages(add, packageNames, callerBinder);
+        }
     }
 
     private class PackageManagerLocalImpl implements PackageManagerLocal {

--- a/services/core/java/com/android/server/pm/PrivilegedInstallerHelper.java
+++ b/services/core/java/com/android/server/pm/PrivilegedInstallerHelper.java
@@ -1,0 +1,92 @@
+package com.android.server.pm;
+
+import android.Manifest;
+import android.content.pm.PackageInstaller;
+import android.os.IBinder;
+import android.util.ArrayMap;
+
+import java.util.List;
+
+class PrivilegedInstallerHelper {
+    private final PackageManagerService pm;
+
+    PrivilegedInstallerHelper(PackageManagerService pm) {
+        this.pm = pm;
+    }
+
+    // The purpose of this method is to provide a data structure that allows instances of privileged
+    // installers across all users avoid installing the same package at the same time.
+    //
+    // Example:
+    // Installer A in user #1 starts atomic installation of packages P1, P2, P3.
+    // At the same time,
+    // installer B in user #2 starts atomic installation of packages P2, P4, P5.
+    // If both installers use this method to add their packages to the list of busy packages before
+    // starting the installation process, it's guaranteed to return true in at most one of the
+    // installers (it can return false in both if some of the packages are already busy).
+    //
+    // After installation completes, package names need to be manually removed from the list of busy
+    // packages. If the installer process dies, packages that were added by it are removed from the
+    // list automatically.
+    //
+    // Note that this approach doesn't handle installer process dying before installation completes
+    // (after PackageInstaller session is committed, installation proceeds regardless of whether the
+    // installer is still alive). Handling this would increase the complexity significantly.
+    // In the vast majority of cases, installer remains alive for the whole duration of package
+    // installation.
+
+    private static final int BUSY_PACKAGES_MAX_NUM = 1000;
+    private final ArrayMap<String, IBinder> busyPackages = new ArrayMap<>();
+
+    boolean updateListOfBusyPackages(boolean add, // true is add, false is remove
+                                     List<String> packageNames, IBinder callerBinder) {
+        pm.mContext.enforceCallingPermission(Manifest.permission.INSTALL_PACKAGES, null);
+
+        for (String packageName : packageNames) {
+            if (packageName.length() > PackageInstaller.SessionParams.MAX_PACKAGE_NAME_LENGTH) {
+                throw new IllegalArgumentException();
+            }
+        }
+
+        ArrayMap<String, IBinder> busyPackages = this.busyPackages;
+
+        synchronized (busyPackages) {
+            // remove packages that were marked as busy by processes that no longer exist
+            busyPackages.values().removeIf(e -> !e.pingBinder());
+
+            if (add) {
+                int remainingCapacity = BUSY_PACKAGES_MAX_NUM - busyPackages.size();
+
+                if (remainingCapacity < packageNames.size()) {
+                    return false;
+                }
+
+                // check that none of the packages are busy to ensure atomicity
+                for (String packageName : packageNames) {
+                    if (busyPackages.containsKey(packageName)) {
+                        return false;
+                    }
+                }
+
+                for (String packageName : packageNames) {
+                    busyPackages.put(packageName, callerBinder);
+                }
+
+                return true;
+            } else {
+                // check that all packages were previously marked as busy by the caller
+                for (String packageName : packageNames) {
+                    if (!callerBinder.equals(busyPackages.get(packageName))) {
+                        throw new IllegalStateException(packageName + " was not added by the caller");
+                    }
+                }
+
+                for (String packageName : packageNames) {
+                    busyPackages.remove(packageName);
+                }
+
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a global data structure that is accessible by privileged installers and allows them to avoid
installing the same package at the same time.

See [comment](https://github.com/GrapheneOS/platform_frameworks_base/pull/340/files#diff-9c635162554e5e2302b81de238ff5c3a0882d9523b179ac64cb329c1cb430d76R17)