### PR TITLE
prevent Play services adding Wallet tile by itself

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/QuickAccessWalletTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/QuickAccessWalletTile.java
@@ -177,7 +177,9 @@ public class QuickAccessWalletTile extends QSTileImpl<QSTile.State> {
         return mPackageManager.hasSystemFeature(PackageManager.FEATURE_NFC_HOST_CARD_EMULATION)
                 && !mPackageManager.hasSystemFeature(FEATURE_CHROME_OS)
                 && mSecureSettings.getStringForUser(NFC_PAYMENT_DEFAULT_COMPONENT,
-                    UserHandle.USER_CURRENT) != null;
+                    UserHandle.USER_CURRENT) != null
+                && mSecureSettings.getStringForUser(NFC_PAYMENT_DEFAULT_COMPONENT,
+                    UserHandle.USER_CURRENT) != "com.google.android.gms/com.google.android.gms.tapandpay.hce.service.TpHceService";
     }
 
     @Nullable


### PR DESCRIPTION
the Wallet tile is a system tile that checks if NFC is supported on the device and if there's a registered default NFC payment provider using the secure setting "nfc_payment_default_component". if both of these are true, then the wallet tile will be reported as available to be added.

the tile can still be added manually and is still fully functional.

some users get confused or weirded out that this happens, and Google Pay / Wallet for NFC payments do not work on GrapheneOS at the moment so lets just make them happy.


before installing sandboxed Google Play
```
oriole:/ # settings list secure | grep -i NFC_PAYMENT_DEFAULT_COMPONENT
nfc_payment_default_component=null
```

after:
```
oriole:/ # settings list secure | grep -i NFC_PAYMENT_DEFAULT_COMPONENT
nfc_payment_default_component=com.google.android.gms/com.google.android.gms.tapandpay.hce.service.TpHceService
```

