### PR TITLE
add toggle to remove FLAG_SECURE from all windows

### DIFF
--- a/core/java/android/ext/settings/ExtSettings.java
+++ b/core/java/android/ext/settings/ExtSettings.java
@@ -46,6 +46,9 @@ public class ExtSettings {
             // also accessed in native code, in frameworks/native/cmds/servicemanager/Access.cpp
             "persist.sys.allow_google_apps_special_access_to_accelerators", true);
 
+    public static final BoolSetting WINDOW_IGNORE_SECURE = new BoolSetting(
+            Setting.Scope.PER_USER, "window_ignore_secure", false);
+
     private ExtSettings() {}
 
     // used for making settings defined in this class unreadable by third-party apps

--- a/core/java/android/view/Window.java
+++ b/core/java/android/view/Window.java
@@ -20,6 +20,7 @@ import static android.Manifest.permission.HIDE_NON_SYSTEM_OVERLAY_WINDOWS;
 import static android.Manifest.permission.HIDE_OVERLAY_WINDOWS;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static android.view.WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED;
+import static android.view.WindowManager.LayoutParams.FLAG_SECURE;
 import static android.view.WindowManager.LayoutParams.SYSTEM_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS;
 
 import android.annotation.ColorInt;
@@ -40,6 +41,7 @@ import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.ext.settings.ExtSettings;
 import android.graphics.Insets;
 import android.graphics.PixelFormat;
 import android.graphics.Rect;
@@ -1274,6 +1276,9 @@ public abstract class Window {
      * @see #clearFlags
      */
     public void setFlags(int flags, int mask) {
+        if ((mask & FLAG_SECURE) != 0 && ExtSettings.WINDOW_IGNORE_SECURE.get(getContext())) {
+            mask &= ~FLAG_SECURE;
+        }
         final WindowManager.LayoutParams attrs = getAttributes();
         attrs.flags = (attrs.flags&~mask) | (flags&mask);
         mForcedWindowFlags |= mask;


### PR DESCRIPTION
Depends on https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/162

Solves https://github.com/GrapheneOS/os-issue-tracker/issues/1915