### PR TITLE
improve and simplify the InternetCompat implementation 

### DIFF
--- a/apex/jobscheduler/service/java/com/android/server/job/controllers/JobStatus.java
+++ b/apex/jobscheduler/service/java/com/android/server/job/controllers/JobStatus.java
@@ -1677,6 +1677,23 @@ public final class JobStatus {
             return true;
         }
 
+        if ((mRequiredConstraintsOfInterest & CONSTRAINT_CONNECTIVITY) != 0) {
+            if ((satisfiedConstraints & CONSTRAINT_CONNECTIVITY) != 0) {
+                var pmi = LocalServices.getService(
+                        com.android.server.pm.permission.PermissionManagerServiceInternal.class);
+
+                if (pmi.checkUidPermission(getSourceUid(), android.Manifest.permission.INTERNET) !=
+                        android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                    if (DEBUG) {
+                        Slog.d(TAG, "skipping job " + getJobId() + " for " + getSourcePackageName()
+                                + " in user " + getSourceUserId() + ": it has CONSTRAINT_CONNECTIVITY, "
+                                + "but its UID doesn't have the INTERNET permission");
+                    }
+                    return false;
+                }
+            }
+        }
+
         int sat = satisfiedConstraints;
         if (overrideState == OVERRIDE_SOFT) {
             // override: pretend all 'soft' requirements are satisfied

--- a/core/api/system-current.txt
+++ b/core/api/system-current.txt
@@ -3637,11 +3637,7 @@ package android.content.pm {
   }
 
   public class SpecialRuntimePermAppUtils {
-    method public static boolean awareOfRuntimeInternetPermission();
     method public static boolean isInternetCompatEnabled();
-    method public static boolean requestsInternetPermission();
-    field public static final int FLAG_AWARE_OF_RUNTIME_INTERNET_PERMISSION = 4; // 0x4
-    field public static final int FLAG_REQUESTS_INTERNET_PERMISSION = 2; // 0x2
   }
 
   public final class SuspendDialogInfo implements android.os.Parcelable {

--- a/core/java/android/app/ActivityThreadHooks.java
+++ b/core/java/android/app/ActivityThreadHooks.java
@@ -3,6 +3,7 @@ package android.app;
 import android.annotation.Nullable;
 import android.content.Context;
 import android.content.pm.GosPackageState;
+import android.content.pm.SrtPermissions;
 import android.os.Bundle;
 import android.os.Process;
 import android.os.RemoteException;
@@ -45,6 +46,8 @@ class ActivityThreadHooks {
         }
 
         int[] flags = Objects.requireNonNull(args.getIntArray(AppBindArgs.KEY_FLAGS_ARRAY));
+
+        SrtPermissions.setFlags(flags[AppBindArgs.FLAGS_IDX_SPECIAL_RUNTIME_PERMISSIONS]);
 
         return args;
     }

--- a/core/java/android/app/AppBindArgs.java
+++ b/core/java/android/app/AppBindArgs.java
@@ -5,5 +5,7 @@ public interface AppBindArgs {
     String KEY_GOS_PACKAGE_STATE = "gosPs";
     String KEY_FLAGS_ARRAY = "flagsArr";
 
+    int FLAGS_IDX_SPECIAL_RUNTIME_PERMISSIONS = 0;
+
     int FLAGS_ARRAY_LEN = 10;
 }

--- a/core/java/android/content/pm/AppPermissionUtils.java
+++ b/core/java/android/content/pm/AppPermissionUtils.java
@@ -16,7 +16,6 @@
 
 package android.content.pm;
 
-import android.Manifest;
 import android.annotation.NonNull;
 import android.annotation.SystemApi;
 import android.app.compat.gms.GmsCompat;
@@ -42,11 +41,7 @@ public class AppPermissionUtils {
             return true;
         }
 
-        if (Manifest.permission.INTERNET.equals(permName)
-                && SpecialRuntimePermAppUtils.requestsInternetPermission()
-                && !SpecialRuntimePermAppUtils.awareOfRuntimeInternetPermission())
-        {
-            SpecialRuntimePermAppUtils.isInternetPermissionCheckSpoofed = true;
+        if (SrtPermissions.shouldSpoofSelfCheck(permName)) {
             return true;
         }
 

--- a/core/java/android/content/pm/IPackageManager.aidl
+++ b/core/java/android/content/pm/IPackageManager.aidl
@@ -804,8 +804,6 @@ interface IPackageManager {
 
     boolean canPackageQuery(String sourcePackageName, String targetPackageName, int userId);
 
-    int getSpecialRuntimePermissionFlags(String packageName);
-
     android.content.pm.GosPackageState getGosPackageState(String packageName, int userId);
 
     boolean setGosPackageState(String packageName, int userId, in android.content.pm.GosPackageState updatedPs, int editorFlags);

--- a/core/java/android/content/pm/SpecialRuntimePermAppUtils.java
+++ b/core/java/android/content/pm/SpecialRuntimePermAppUtils.java
@@ -16,64 +16,21 @@
 
 package android.content.pm;
 
-import android.Manifest;
 import android.annotation.SystemApi;
-import android.app.ActivityThread;
-import android.app.AppGlobals;
-import android.content.Context;
-import android.os.Binder;
-import android.os.RemoteException;
 
 /** @hide */
 @SystemApi
 public class SpecialRuntimePermAppUtils {
-    private static final int FLAG_INITED = 1;
-    public static final int FLAG_REQUESTS_INTERNET_PERMISSION = 1 << 1;
-    public static final int FLAG_AWARE_OF_RUNTIME_INTERNET_PERMISSION = 1 << 2;
 
-    private static volatile int cachedFlags;
+    private static boolean isInternetCompatEnabled;
 
     /** @hide */
-    public static boolean isInternetPermissionCheckSpoofed;
-
-    private static boolean hasInternetPermission() {
-        Context ctx = ActivityThread.currentApplication();
-        boolean res = ctx.checkSelfPermission(Manifest.permission.INTERNET) == PackageManager.PERMISSION_GRANTED;
-        if (res && isInternetPermissionCheckSpoofed) {
-            res = false;
-        }
-        return res;
-    }
-
-    public static boolean requestsInternetPermission() {
-        return (getFlags() & FLAG_REQUESTS_INTERNET_PERMISSION) != 0;
-    }
-
-    public static boolean awareOfRuntimeInternetPermission() {
-        return (getFlags() & FLAG_AWARE_OF_RUNTIME_INTERNET_PERMISSION) != 0;
+    public static void enableInternetCompat() {
+        isInternetCompatEnabled = true;
     }
 
     public static boolean isInternetCompatEnabled() {
-        return !hasInternetPermission() && requestsInternetPermission() && !awareOfRuntimeInternetPermission();
-    }
-
-    private static int getFlags() {
-        int cache = cachedFlags;
-        if (cache != 0) {
-            return cache;
-        }
-
-        IPackageManager pm = AppGlobals.getPackageManager();
-        String pkgName = AppGlobals.getInitialPackage();
-
-        final long token = Binder.clearCallingIdentity(); // in case this method is called in the system_server
-        try {
-            return (cachedFlags = pm.getSpecialRuntimePermissionFlags(pkgName) | FLAG_INITED);
-        } catch (RemoteException e) {
-            throw e.rethrowFromSystemServer();
-        } finally {
-            Binder.restoreCallingIdentity(token);
-        }
+        return isInternetCompatEnabled;
     }
 
     private SpecialRuntimePermAppUtils() {}

--- a/core/java/android/content/pm/SrtPermissions.java
+++ b/core/java/android/content/pm/SrtPermissions.java
@@ -1,0 +1,31 @@
+package android.content.pm;
+
+import android.Manifest;
+
+/** @hide */
+public class SrtPermissions { // "special runtime permissions"
+    public static final int FLAG_INTERNET_COMPAT_ENABLED = 1;
+
+    private static int flags;
+
+    public static int getFlags() {
+        return flags;
+    }
+
+    public static void setFlags(int value) {
+        flags = value;
+
+        if ((value & FLAG_INTERNET_COMPAT_ENABLED) != 0) {
+            SpecialRuntimePermAppUtils.enableInternetCompat();
+        }
+    }
+
+    public static boolean shouldSpoofSelfCheck(String permName) {
+        switch (permName) {
+            case Manifest.permission.INTERNET:
+                return SpecialRuntimePermAppUtils.isInternetCompatEnabled();
+        }
+
+        return false;
+    }
+}

--- a/services/core/java/com/android/server/ext/PackageManagerHooks.java
+++ b/services/core/java/com/android/server/ext/PackageManagerHooks.java
@@ -18,6 +18,7 @@ import com.android.internal.util.GoogleEuicc;
 import com.android.server.pm.GosPackageStatePmHooks;
 import com.android.server.pm.PackageManagerService;
 import com.android.server.pm.parsing.pkg.AndroidPackage;
+import com.android.server.pm.permission.SpecialRuntimePermUtils;
 import com.android.server.pm.pkg.GosPackageStatePm;
 import com.android.server.pm.pkg.PackageStateInternal;
 import com.android.server.pm.pkg.parsing.ParsingPackage;
@@ -111,6 +112,8 @@ public class PackageManagerHooks {
         GosPackageState gosPs = GosPackageStatePmHooks.get(pm, callingUid, packageName, userId);
 
         int[] flagsArr = new int[AppBindArgs.FLAGS_ARRAY_LEN];
+        flagsArr[AppBindArgs.FLAGS_IDX_SPECIAL_RUNTIME_PERMISSIONS] =
+                SpecialRuntimePermUtils.getFlags(pm, pkg, pkgState, userId);
 
         var b = new Bundle();
         b.putParcelable(AppBindArgs.KEY_GOS_PACKAGE_STATE, gosPs);

--- a/services/core/java/com/android/server/ext/PackageManagerHooks.java
+++ b/services/core/java/com/android/server/ext/PackageManagerHooks.java
@@ -93,7 +93,13 @@ public class PackageManagerHooks {
         final int appId = UserHandle.getAppId(callingUid);
         final int userId = UserHandle.getUserId(callingUid);
 
-        AndroidPackage pkg = pm.snapshotComputer().getPackage(packageName);
+        PackageStateInternal pkgState = pm.snapshotComputer().getPackageStateInternal(packageName);
+        if (pkgState == null) {
+            return null;
+        }
+
+        AndroidPackage pkg = pkgState.getPkg();
+
         if (pkg == null) {
             return null;
         }

--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -6047,22 +6047,6 @@ public class PackageManagerService implements PackageSender, TestUtilityService 
         }
 
         @Override
-        public int getSpecialRuntimePermissionFlags(String packageName) {
-            final int callingUid = Binder.getCallingUid();
-
-            AndroidPackage pkg = snapshot().getPackage(packageName);
-            if (pkg == null) {
-                throw new IllegalStateException();
-            }
-
-            if (UserHandle.getAppId(callingUid) != pkg.getUid()) { // getUid() confusingly returns appId
-                throw new SecurityException();
-            }
-
-            return SpecialRuntimePermUtils.getFlags(pkg);
-        }
-
-        @Override
         public GosPackageState getGosPackageState(@NonNull String packageName, int userId) {
             return GosPackageStatePmHooks.get(PackageManagerService.this, packageName, userId);
         }


### PR DESCRIPTION
- decide whether to enable InternetCompat in system_server (it's faster and simpler), and pass the
result to the app along with other arguments in AppBindArgs in a single IPC
- remove `getSpecialRuntimePermissionFlags()` PackageManager method that is no longer needed
- passing InternetCompat state through AppBindArgs makes it available during early app init, which
wasn't the case before. This allows to replace the ConnectivityManager with a special
ConnectivityManagerInternetCompat implementation that overrides a large number of methods to improve
the behavior of apps that don't expect the INTERNET permission to be revoked