### PR TITLE
add connectivity checks setting and its migration from Settings.Global; +ExtSettings migrations

### DIFF
--- a/core/api/system-current.txt
+++ b/core/api/system-current.txt
@@ -3857,6 +3857,19 @@ package android.ext.cscopes {
 
 }
 
+package android.ext.settings {
+
+  public class ConnChecksSetting {
+    method public static int get();
+    method public static boolean put(int);
+    field public static final int VAL_DEFAULT = 0; // 0x0
+    field public static final int VAL_DISABLED = 2; // 0x2
+    field public static final int VAL_GRAPHENEOS = 0; // 0x0
+    field public static final int VAL_STANDARD = 1; // 0x1
+  }
+
+}
+
 package android.graphics.fonts {
 
   public final class FontFamilyUpdateRequest {

--- a/core/java/android/ext/settings/ConnChecksSetting.java
+++ b/core/java/android/ext/settings/ConnChecksSetting.java
@@ -1,0 +1,32 @@
+package android.ext.settings;
+
+import android.annotation.SystemApi;
+import android.os.SystemProperties;
+
+/** @hide */
+@SystemApi
+public class ConnChecksSetting {
+
+    public static final int VAL_GRAPHENEOS = 0;
+    public static final int VAL_STANDARD = 1;
+    public static final int VAL_DISABLED = 2;
+    public static final int VAL_DEFAULT = VAL_GRAPHENEOS;
+
+    public static int get() {
+        return ExtSettings.CONNECTIVITY_CHECKS.get();
+    }
+
+    public static boolean put(int val) {
+        return ExtSettings.CONNECTIVITY_CHECKS.put(val);
+    }
+
+    /**
+     * Use only during migration, to decide whether to perform it.
+     * @hide
+     */
+    public static boolean isSet() {
+        return !SystemProperties.get(ExtSettings.CONNECTIVITY_CHECKS.getKey()).isEmpty();
+    }
+
+    private ConnChecksSetting() {}
+}

--- a/core/java/android/ext/settings/ExtSettings.java
+++ b/core/java/android/ext/settings/ExtSettings.java
@@ -93,6 +93,32 @@ public class ExtSettings {
     public static final IntSetting BLUETOOTH_AUTO_OFF = new IntSetting(
             Setting.Scope.GLOBAL, "bluetooth_off_timeout", 0 /* off by default */);
 
+    public static final String DENY_NEW_USB_DISABLED = "disabled";
+    public static final String DENY_NEW_USB_DYNAMIC = "dynamic";
+    public static final String DENY_NEW_USB_ENABLED = "enabled";
+    // also specified in build/make/core/main.mk
+    public static final String DENY_NEW_USB_DEFAULT = DENY_NEW_USB_DYNAMIC;
+
+    // see system/core/rootdir/init.rc
+    public static final String DENY_NEW_USB_TRANSIENT_PROP = "security.deny_new_usb";
+    public static final String DENY_NEW_USB_TRANSIENT_ENABLE = "1";
+    public static final String DENY_NEW_USB_TRANSIENT_DISABLE = "0";
+
+    public static final StringSysProperty DENY_NEW_USB = new StringSysProperty(
+            "persist.security.deny_new_usb", DENY_NEW_USB_DEFAULT) {
+        @Override
+        public boolean validateValue(String val) {
+            switch (val) {
+                case DENY_NEW_USB_DISABLED:
+                case DENY_NEW_USB_DYNAMIC:
+                case DENY_NEW_USB_ENABLED:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    };
+
     private ExtSettings() {}
 
     // used for making settings defined in this class unreadable by third-party apps

--- a/core/java/android/ext/settings/ExtSettings.java
+++ b/core/java/android/ext/settings/ExtSettings.java
@@ -85,6 +85,10 @@ public class ExtSettings {
             ConnChecksSetting.VAL_GRAPHENEOS, ConnChecksSetting.VAL_STANDARD, ConnChecksSetting.VAL_DISABLED
     );
 
+    // The amount of time in milliseconds before a disconnected Wi-Fi adapter is turned off
+    public static final IntSetting WIFI_AUTO_OFF = new IntSetting(
+            Setting.Scope.GLOBAL, "wifi_off_timeout", 0 /* off by default */);
+
     private ExtSettings() {}
 
     // used for making settings defined in this class unreadable by third-party apps

--- a/core/java/android/ext/settings/ExtSettings.java
+++ b/core/java/android/ext/settings/ExtSettings.java
@@ -89,6 +89,10 @@ public class ExtSettings {
     public static final IntSetting WIFI_AUTO_OFF = new IntSetting(
             Setting.Scope.GLOBAL, "wifi_off_timeout", 0 /* off by default */);
 
+    // The amount of time in milliseconds before a disconnected Bluetooth adapter is turned off
+    public static final IntSetting BLUETOOTH_AUTO_OFF = new IntSetting(
+            Setting.Scope.GLOBAL, "bluetooth_off_timeout", 0 /* off by default */);
+
     private ExtSettings() {}
 
     // used for making settings defined in this class unreadable by third-party apps

--- a/core/java/android/ext/settings/ExtSettings.java
+++ b/core/java/android/ext/settings/ExtSettings.java
@@ -78,6 +78,13 @@ public class ExtSettings {
             // also accessed in native code, in frameworks/native/cmds/servicemanager/Access.cpp
             "persist.sys.allow_google_apps_special_access_to_accelerators", true);
 
+    // also read in packages/modules/DnsResolver (DnsTlsTransport.cpp and doh/network/driver.rs)
+    public static final IntSysProperty CONNECTIVITY_CHECKS = new IntSysProperty(
+            "persist.sys.connectivity_checks",
+            ConnChecksSetting.VAL_DEFAULT,
+            ConnChecksSetting.VAL_GRAPHENEOS, ConnChecksSetting.VAL_STANDARD, ConnChecksSetting.VAL_DISABLED
+    );
+
     private ExtSettings() {}
 
     // used for making settings defined in this class unreadable by third-party apps

--- a/core/java/android/ext/settings/ExtSettings.java
+++ b/core/java/android/ext/settings/ExtSettings.java
@@ -122,6 +122,9 @@ public class ExtSettings {
     public static final BoolSysProperty EXEC_SPAWNING = new BoolSysProperty(
             "persist.security.exec_spawn", true);
 
+    public static final BoolSysProperty NATIVE_DEBUGGING = new BoolSysProperty(
+            "persist.native_debug", true);
+
     private ExtSettings() {}
 
     // used for making settings defined in this class unreadable by third-party apps

--- a/core/java/android/ext/settings/ExtSettings.java
+++ b/core/java/android/ext/settings/ExtSettings.java
@@ -119,6 +119,9 @@ public class ExtSettings {
         }
     };
 
+    public static final BoolSysProperty EXEC_SPAWNING = new BoolSysProperty(
+            "persist.security.exec_spawn", true);
+
     private ExtSettings() {}
 
     // used for making settings defined in this class unreadable by third-party apps

--- a/core/java/android/ext/settings/IntSysProperty.java
+++ b/core/java/android/ext/settings/IntSysProperty.java
@@ -28,6 +28,6 @@ public class IntSysProperty extends IntSetting {
     }
 
     public boolean put(int val) {
-        return super.put(null, UserHandle.USER_SYSTEM);
+        return super.put(null, val);
     }
 }

--- a/core/java/android/ext/settings/StringSysProperty.java
+++ b/core/java/android/ext/settings/StringSysProperty.java
@@ -1,0 +1,25 @@
+package android.ext.settings;
+
+import android.os.UserHandle;
+
+import java.util.function.Supplier;
+
+/** @hide */
+public class StringSysProperty extends StringSetting {
+
+    public StringSysProperty(String key, String defaultValue) {
+        super(Scope.SYSTEM_PROPERTY, key, defaultValue);
+    }
+
+    public StringSysProperty(String key, Supplier<String> defaultValue) {
+        super(Scope.SYSTEM_PROPERTY, key, defaultValue);
+    }
+
+    public String get() {
+        return super.get(null, UserHandle.USER_SYSTEM);
+    }
+
+    public boolean put(String val) {
+        return super.put(null, val);
+    }
+}

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -17308,12 +17308,6 @@ public final class Settings {
 
 
         /**
-         * The amount of time in milliseconds before a disconnected Wi-Fi adapter is turned off
-         * @hide
-         */
-        public static final String WIFI_OFF_TIMEOUT = "wifi_off_timeout";
-
-        /**
          * The amount of time in milliseconds before a disconnected Bluetooth adapter is turned off
          * @hide
          */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -17306,13 +17306,6 @@ public final class Settings {
         public static final String REVIEW_PERMISSIONS_NOTIFICATION_STATE =
                 "review_permissions_notification_state";
 
-
-        /**
-         * The amount of time in milliseconds before a disconnected Bluetooth adapter is turned off
-         * @hide
-         */
-        public static final String BLUETOOTH_OFF_TIMEOUT = "bluetooth_off_timeout";
-
         /**
          * Settings migrated from Wear OS settings provider.
          * @hide

--- a/core/java/com/android/internal/os/ZygoteConnection.java
+++ b/core/java/com/android/internal/os/ZygoteConnection.java
@@ -25,6 +25,7 @@ import static com.android.internal.os.ZygoteConnectionConstants.WRAPPED_PID_TIME
 
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.pm.ApplicationInfo;
+import android.ext.settings.ExtSettings;
 import android.net.Credentials;
 import android.net.LocalSocket;
 import android.os.Parcel;
@@ -248,7 +249,7 @@ class ZygoteConnection {
                     fdsToClose[1] = zygoteFd.getInt$();
                 }
 
-                if (parsedArgs.mInvokeWith != null || SystemProperties.getBoolean("persist.security.exec_spawn", true) || parsedArgs.mStartChildZygote
+                if (parsedArgs.mInvokeWith != null || ExtSettings.EXEC_SPAWNING.get() || parsedArgs.mStartChildZygote
                         || !multipleOK || peer.getUid() != Process.SYSTEM_UID
                         || (parsedArgs.mRuntimeFlags & Zygote.RUNTIME_FLAGS_DEPENDENT_ON_EXEC_SPAWNING) != 0) {
                     // Continue using old code for now. TODO: Handle these cases in the other path.
@@ -540,7 +541,7 @@ class ZygoteConnection {
                 final int runtimeFlags = parsedArgs.mRuntimeFlags;
                 boolean useExecInit =
                         ((runtimeFlags & Zygote.RUNTIME_FLAGS_DEPENDENT_ON_EXEC_SPAWNING) != 0
-                            || SystemProperties.getBoolean("persist.security.exec_spawn", true))
+                            || ExtSettings.EXEC_SPAWNING.get())
                         &&
                         (runtimeFlags & ApplicationInfo.FLAG_DEBUGGABLE) == 0;
 

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsParserState.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsParserState.java
@@ -1,10 +1,14 @@
 package com.android.providers.settings;
 
+import android.ext.settings.ConnChecksSetting;
 import android.provider.Settings;
 import android.util.Log;
 
 class SettingsParserState {
     private final int type;
+
+    private String captivePortalHttpsUrl;
+    private String captivePortalMode;
 
     SettingsParserState(int type) {
         this.type = type;
@@ -19,6 +23,19 @@ class SettingsParserState {
         switch (type) {
             case SettingsState.SETTINGS_TYPE_GLOBAL: {
                 switch (key) {
+                    case Settings.Global.CAPTIVE_PORTAL_HTTPS_URL:
+                        captivePortalHttpsUrl = val;
+                        // fallthrough
+                    case Settings.Global.CAPTIVE_PORTAL_HTTP_URL:
+                    case Settings.Global.CAPTIVE_PORTAL_FALLBACK_URL:
+                    case Settings.Global.CAPTIVE_PORTAL_OTHER_FALLBACK_URLS:
+                        // skip legacy captive portal detection URLs, remember one of them for
+                        // migration in onFinish()
+                        return false;
+                    case Settings.Global.CAPTIVE_PORTAL_MODE:
+                        // checked during migration of connectivity checks setting
+                        captivePortalMode = val;
+                        return false;
                     default:
                         break;
                 }
@@ -39,11 +56,34 @@ class SettingsParserState {
     void onFinish() {
         switch (type) {
             case SettingsState.SETTINGS_TYPE_GLOBAL: {
+                maybeMigrateConnChecksSetting();
                 return;
             }
             case SettingsState.SETTINGS_TYPE_SECURE: {
                 return;
             }
         }
+    }
+
+    private void maybeMigrateConnChecksSetting() {
+        if (ConnChecksSetting.isSet()) {
+            return;
+        }
+
+        final int val;
+        boolean connChecksDisabled = Integer.toString(Settings.Global.CAPTIVE_PORTAL_MODE_IGNORE)
+                .equals(captivePortalMode);
+
+        if (connChecksDisabled) {
+            val = ConnChecksSetting.VAL_DISABLED;
+        } else {
+            if ("https://www.google.com/generate_204".equals(captivePortalHttpsUrl)) {
+                val = ConnChecksSetting.VAL_STANDARD;
+            } else {
+                val = ConnChecksSetting.VAL_GRAPHENEOS;
+            }
+        }
+
+        ConnChecksSetting.put(val);
     }
 }

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsParserState.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsParserState.java
@@ -1,0 +1,49 @@
+package com.android.providers.settings;
+
+import android.provider.Settings;
+import android.util.Log;
+
+class SettingsParserState {
+    private final int type;
+
+    SettingsParserState(int type) {
+        this.type = type;
+    }
+
+    // Return false to discard the setting
+    boolean onSettingRead(String key, String val) {
+        if (key == null) {
+            return true;
+        }
+
+        switch (type) {
+            case SettingsState.SETTINGS_TYPE_GLOBAL: {
+                switch (key) {
+                    default:
+                        break;
+                }
+                break;
+            }
+            case SettingsState.SETTINGS_TYPE_SECURE: {
+                switch (key) {
+                    default:
+                        break;
+                }
+                break;
+            }
+        }
+
+        return true;
+    }
+
+    void onFinish() {
+        switch (type) {
+            case SettingsState.SETTINGS_TYPE_GLOBAL: {
+                return;
+            }
+            case SettingsState.SETTINGS_TYPE_SECURE: {
+                return;
+            }
+        }
+    }
+}

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsState.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsState.java
@@ -1129,6 +1129,8 @@ final class SettingsState {
 
         mVersion = parser.getAttributeInt(null, ATTR_VERSION);
 
+        final SettingsParserState state = new SettingsParserState(getTypeFromKey(mKey));
+
         final int outerDepth = parser.getDepth();
         int type;
         while ((type = parser.next()) != XmlPullParser.END_DOCUMENT
@@ -1142,6 +1144,9 @@ final class SettingsState {
                 String id = parser.getAttributeValue(null, ATTR_ID);
                 String name = parser.getAttributeValue(null, ATTR_NAME);
                 String value = getValueAttribute(parser, ATTR_VALUE, ATTR_VALUE_BASE64);
+                if (!state.onSettingRead(name, value)) {
+                    continue;
+                }
                 String packageName = parser.getAttributeValue(null, ATTR_PACKAGE);
                 String defaultValue = getValueAttribute(parser, ATTR_DEFAULT_VALUE,
                         ATTR_DEFAULT_VALUE_BASE64);
@@ -1161,6 +1166,8 @@ final class SettingsState {
                 }
             }
         }
+
+        state.onFinish();
     }
 
     @GuardedBy("mLock")

--- a/services/core/java/com/android/server/ext/BluetoothAutoOff.java
+++ b/services/core/java/com/android/server/ext/BluetoothAutoOff.java
@@ -8,8 +8,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.ext.settings.ExtSettings;
 import android.os.Build;
-import android.provider.Settings;
 import android.util.Slog;
 
 class BluetoothAutoOff extends DelayedConditionalAction {
@@ -18,7 +18,7 @@ class BluetoothAutoOff extends DelayedConditionalAction {
     private final BluetoothAdapter adapter;
 
     BluetoothAutoOff(SystemServerExt sse) {
-        super(sse, sse.bgHandler);
+        super(sse, ExtSettings.BLUETOOTH_AUTO_OFF, sse.bgHandler);
         manager = sse.context.getSystemService(BluetoothManager.class);
         adapter = manager.getAdapter();
     }
@@ -70,10 +70,5 @@ class BluetoothAutoOff extends DelayedConditionalAction {
         }
 
         return false;
-    }
-
-    @Override
-    protected String getDelayGlobalSettingsKey() {
-        return Settings.Global.BLUETOOTH_OFF_TIMEOUT;
     }
 }

--- a/services/core/java/com/android/server/ext/WifiAutoOff.java
+++ b/services/core/java/com/android/server/ext/WifiAutoOff.java
@@ -4,17 +4,17 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.ext.settings.ExtSettings;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.os.Build;
-import android.provider.Settings;
 import android.util.Slog;
 
 class WifiAutoOff extends DelayedConditionalAction {
     private final WifiManager wifiManager;
 
     WifiAutoOff(SystemServerExt sse) {
-        super(sse, sse.bgHandler);
+        super(sse, ExtSettings.WIFI_AUTO_OFF, sse.bgHandler);
         wifiManager = sse.context.getSystemService(WifiManager.class);
     }
 
@@ -60,10 +60,5 @@ class WifiAutoOff extends DelayedConditionalAction {
                 update();
             }
         }, f, handler);
-    }
-
-    @Override
-    protected String getDelayGlobalSettingsKey() {
-        return Settings.Global.WIFI_OFF_TIMEOUT;
     }
 }

--- a/services/core/java/com/android/server/pm/GosPackageStatePmHooks.java
+++ b/services/core/java/com/android/server/pm/GosPackageStatePmHooks.java
@@ -603,16 +603,15 @@ public class GosPackageStatePmHooks {
                         | FLAG_DISABLE_HARDENED_MALLOC
                         | FLAG_ENABLE_COMPAT_VA_39_BIT;
 
+            final int settingsWriteFlags = FLAG_ALLOW_ACCESS_TO_OBB_DIRECTORY
+                        | FLAG_DISABLE_HARDENED_MALLOC
+                        | FLAG_ENABLE_COMPAT_VA_39_BIT;
+
             // note that this applies to all packages that run in the android.uid.system sharedUserId
             // in secondary users, not just the Settings app. Packages that run in this sharedUserId
             // in the primary user get the fullPermission declared above
             grantPermission(pm, "com.android.settings",
-                    Permission.readWrite(
-                        // read flags
-                        settingsReadFlags,
-                        // write flags
-                        settingsReadFlags & ~FLAG_STORAGE_SCOPES_ENABLED
-                    , 0, 0));
+                    Permission.readWrite(settingsReadFlags, settingsWriteFlags, 0, 0));
 
             userManager = Objects.requireNonNull(LocalServices.getService(UserManagerInternal.class));
 

--- a/services/core/java/com/android/server/policy/keyguard/KeyguardStateMonitor.java
+++ b/services/core/java/com/android/server/policy/keyguard/KeyguardStateMonitor.java
@@ -18,6 +18,7 @@ package com.android.server.policy.keyguard;
 
 import android.app.ActivityManager;
 import android.content.Context;
+import android.ext.settings.ExtSettings;
 import android.os.RemoteException;
 import android.os.SystemProperties;
 import android.util.Slog;
@@ -91,8 +92,10 @@ public class KeyguardStateMonitor extends IKeyguardStateCallback.Stub {
 
         mCallback.onShowingChanged();
 
-        if ("dynamic".equals(SystemProperties.get("persist.security.deny_new_usb"))) {
-            SystemProperties.set("security.deny_new_usb", showing ? "1" : "0");
+        if (ExtSettings.DENY_NEW_USB_DYNAMIC.equals(ExtSettings.DENY_NEW_USB.get())) {
+            SystemProperties.set(ExtSettings.DENY_NEW_USB_TRANSIENT_PROP, showing ?
+                    ExtSettings.DENY_NEW_USB_TRANSIENT_ENABLE :
+                    ExtSettings.DENY_NEW_USB_TRANSIENT_DISABLE);
         }
     }
 


### PR DESCRIPTION
Part of a changelist:
https://github.com/GrapheneOS/platform_packages_modules_NetworkStack/pull/5
https://github.com/GrapheneOS/platform_packages_modules_DnsResolver/pull/1
https://github.com/GrapheneOS/platform_packages_modules_Connectivity/pull/17
https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/172
https://github.com/GrapheneOS/platform_system_librustutils/pull/1

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/2013