### PR TITLE
SystemUI: specify config_sceenshotWorkProfileFilesApp

### DIFF
--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -440,7 +440,7 @@
     <!-- ComponentName for the file browsing app that the system would expect to be used in work
          profile. The icon for this app will be shown to the user when informing them that a
          screenshot has been saved to work profile. If blank, a default icon will be shown. -->
-    <string name="config_sceenshotWorkProfileFilesApp" translatable="false"></string>
+    <string name="config_sceenshotWorkProfileFilesApp" translatable="false">com.android.documentsui/.files.LauncherActivity</string>
 
     <!-- Remote copy default activity.  Must handle REMOTE_COPY_ACTION intents.
      This name is in the ComponentName flattened format (package/class)  -->


### PR DESCRIPTION
This resource is overridden with an overlay on stock OS to Google Files app. If it's empty, SystemUI crashes after screenshot of a work profile app is taken. Screenshot was still saved, crash happened when constructing post-screenshot UI.

"sceenshot" typo is upstream.