### PR TITLE
improve compat with apps that try to access network location provider

### DIFF
--- a/core/java/android/app/ActivityThreadHooks.java
+++ b/core/java/android/app/ActivityThreadHooks.java
@@ -4,6 +4,7 @@ import android.annotation.Nullable;
 import android.content.Context;
 import android.content.pm.GosPackageState;
 import android.content.pm.SrtPermissions;
+import android.location.HookedLocationManager;
 import android.os.Bundle;
 import android.os.Process;
 import android.os.RemoteException;
@@ -48,6 +49,8 @@ class ActivityThreadHooks {
         int[] flags = Objects.requireNonNull(args.getIntArray(AppBindArgs.KEY_FLAGS_ARRAY));
 
         SrtPermissions.setFlags(flags[AppBindArgs.FLAGS_IDX_SPECIAL_RUNTIME_PERMISSIONS]);
+
+        HookedLocationManager.setFlags(flags[AppBindArgs.FLAGS_IDX_HOOKED_LOCATION_MANAGER]);
 
         return args;
     }

--- a/core/java/android/app/AppBindArgs.java
+++ b/core/java/android/app/AppBindArgs.java
@@ -6,6 +6,7 @@ public interface AppBindArgs {
     String KEY_FLAGS_ARRAY = "flagsArr";
 
     int FLAGS_IDX_SPECIAL_RUNTIME_PERMISSIONS = 0;
+    int FLAGS_IDX_HOOKED_LOCATION_MANAGER = 1;
 
     int FLAGS_ARRAY_LEN = 10;
 }

--- a/core/java/android/app/SystemServiceRegistry.java
+++ b/core/java/android/app/SystemServiceRegistry.java
@@ -116,6 +116,7 @@ import android.location.CountryDetector;
 import android.location.ICountryDetector;
 import android.location.ILocationManager;
 import android.location.LocationManager;
+import android.location.HookedLocationManager;
 import android.media.AudioDeviceVolumeManager;
 import android.media.AudioManager;
 import android.media.MediaFrameworkInitializer;
@@ -555,7 +556,11 @@ public final class SystemServiceRegistry {
             @Override
             public LocationManager createService(ContextImpl ctx) throws ServiceNotFoundException {
                 IBinder b = ServiceManager.getServiceOrThrow(Context.LOCATION_SERVICE);
-                return new LocationManager(ctx, ILocationManager.Stub.asInterface(b));
+                if (HookedLocationManager.isEnabled()) {
+                    return new HookedLocationManager(ctx, ILocationManager.Stub.asInterface(b));
+                } else {
+                    return new LocationManager(ctx, ILocationManager.Stub.asInterface(b));
+                }
             }});
 
         registerService(Context.NETWORK_POLICY_SERVICE, NetworkPolicyManager.class,

--- a/location/java/android/location/HookedLocationManager.java
+++ b/location/java/android/location/HookedLocationManager.java
@@ -1,0 +1,103 @@
+package android.location;
+
+import android.annotation.NonNull;
+import android.annotation.Nullable;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.pm.GosPackageStateBase;
+import android.location.provider.ProviderProperties;
+import android.os.CancellationSignal;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+/** @hide */
+public class HookedLocationManager extends LocationManager {
+    private static int flags;
+
+    public static int getFlags(GosPackageStateBase gosPs, boolean isUserApp) {
+        return 0;
+    }
+
+    public static void setFlags(int v) {
+        flags = v;
+    }
+
+    public static boolean isEnabled() {
+        return flags != 0;
+    }
+
+    public HookedLocationManager(@NonNull Context context, @NonNull ILocationManager service) {
+        super(context, service);
+    }
+
+    @Override
+    public boolean isProviderEnabled(@NonNull String provider) {
+        return super.isProviderEnabled(provider);
+    }
+
+    @Nullable
+    @Override
+    public ProviderProperties getProviderProperties(@NonNull String provider) {
+        return super.getProviderProperties(provider);
+    }
+
+    @Nullable
+    @Override
+    public Location getLastKnownLocation(@NonNull String provider,
+                                         @NonNull LastLocationRequest lastLocationRequest) {
+        return super.getLastKnownLocation(provider, lastLocationRequest);
+    }
+
+    @Override
+    public void getCurrentLocation(@NonNull String provider, @NonNull LocationRequest locationRequest,
+                                   @Nullable CancellationSignal cancellationSignal,
+                                   @NonNull Executor executor, @NonNull Consumer<Location> consumer) {
+        super.getCurrentLocation(provider, locationRequest, cancellationSignal, executor, consumer);
+    }
+
+    @Override
+    public void requestLocationUpdates(@NonNull String provider, @NonNull LocationRequest locationRequest,
+                                       @NonNull Executor executor, @NonNull LocationListener listener) {
+        super.requestLocationUpdates(provider, locationRequest, executor, listener);
+    }
+
+    @Override
+    public void requestLocationUpdates(@NonNull String provider, @NonNull LocationRequest locationRequest,
+                                       @NonNull PendingIntent pendingIntent) {
+        super.requestLocationUpdates(provider, locationRequest, pendingIntent);
+    }
+
+    @Override
+    public void requestFlush(@NonNull String provider, @NonNull LocationListener listener, int requestCode) {
+        super.requestFlush(provider, listener, requestCode);
+    }
+
+    @Override
+    public void requestFlush(@NonNull String provider, @NonNull PendingIntent pendingIntent, int requestCode) {
+        super.requestFlush(provider, pendingIntent, requestCode);
+    }
+
+    @Override
+    public void addTestProvider(@NonNull String provider, @NonNull ProviderProperties properties,
+                                @NonNull Set<String> extraAttributionTags) {
+        super.addTestProvider(provider, properties, extraAttributionTags);
+    }
+
+    @Override
+    public void removeTestProvider(@NonNull String provider) {
+        super.removeTestProvider(provider);
+    }
+
+    @Override
+    public void setTestProviderEnabled(@NonNull String provider, boolean enabled) {
+        super.setTestProviderEnabled(provider, enabled);
+    }
+
+    @Override
+    public void setTestProviderLocation(@NonNull String provider, @NonNull Location location) {
+        super.setTestProviderLocation(provider, location);
+    }
+}

--- a/location/java/android/location/HookedLocationManager.java
+++ b/location/java/android/location/HookedLocationManager.java
@@ -15,10 +15,18 @@ import java.util.function.Consumer;
 
 /** @hide */
 public class HookedLocationManager extends LocationManager {
+
+    private static final int FLAG_ENABLE_PROVIDER_TRANSLATION = 1;
+
     private static int flags;
 
     public static int getFlags(GosPackageStateBase gosPs, boolean isUserApp) {
-        return 0;
+        if (isUserApp) {
+            // see comment in translateProvider()
+            return FLAG_ENABLE_PROVIDER_TRANSLATION;
+        } else {
+            return 0;
+        }
     }
 
     public static void setFlags(int v) {
@@ -33,14 +41,51 @@ public class HookedLocationManager extends LocationManager {
         super(context, service);
     }
 
+    private String translateProvider(String provider) {
+        if ((flags & FLAG_ENABLE_PROVIDER_TRANSLATION) == 0) {
+            return provider;
+        }
+
+        // There are apps that try to use NETWORK_PROVIDER even when it's not present in the list
+        // returned by getAllProviders(), which leads to a crash.
+        // As a workaround, redirect NETWORK_PROVIDER calls to an available provider
+        if (NETWORK_PROVIDER.equals(provider)) {
+            // getAllProviders() list is not guaranteed to be static, don't cache it
+            List<String> allProviders = getAllProviders();
+            if (allProviders.contains(NETWORK_PROVIDER)) {
+                return NETWORK_PROVIDER;
+            }
+            if (allProviders.contains(GPS_PROVIDER)) {
+                return GPS_PROVIDER;
+            }
+            if (allProviders.contains(FUSED_PROVIDER)) {
+                return FUSED_PROVIDER;
+            }
+            // PASSIVE_PROVIDER is always present
+            return PASSIVE_PROVIDER;
+        }
+        return provider;
+    }
+
+    private boolean isMissingProvider(String provider) {
+        // getAllProviders() list is not guaranteed to be static, don't cache it
+        return !getAllProviders().contains(provider);
+    }
+
     @Override
     public boolean isProviderEnabled(@NonNull String provider) {
+        if (isMissingProvider(provider)) {
+            return false;
+        }
+
         return super.isProviderEnabled(provider);
     }
 
     @Nullable
     @Override
     public ProviderProperties getProviderProperties(@NonNull String provider) {
+        provider = translateProvider(provider);
+
         return super.getProviderProperties(provider);
     }
 
@@ -48,6 +93,8 @@ public class HookedLocationManager extends LocationManager {
     @Override
     public Location getLastKnownLocation(@NonNull String provider,
                                          @NonNull LastLocationRequest lastLocationRequest) {
+        provider = translateProvider(provider);
+
         return super.getLastKnownLocation(provider, lastLocationRequest);
     }
 
@@ -55,49 +102,78 @@ public class HookedLocationManager extends LocationManager {
     public void getCurrentLocation(@NonNull String provider, @NonNull LocationRequest locationRequest,
                                    @Nullable CancellationSignal cancellationSignal,
                                    @NonNull Executor executor, @NonNull Consumer<Location> consumer) {
+        provider = translateProvider(provider);
+
         super.getCurrentLocation(provider, locationRequest, cancellationSignal, executor, consumer);
     }
 
     @Override
     public void requestLocationUpdates(@NonNull String provider, @NonNull LocationRequest locationRequest,
                                        @NonNull Executor executor, @NonNull LocationListener listener) {
+        provider = translateProvider(provider);
+
         super.requestLocationUpdates(provider, locationRequest, executor, listener);
     }
 
     @Override
     public void requestLocationUpdates(@NonNull String provider, @NonNull LocationRequest locationRequest,
                                        @NonNull PendingIntent pendingIntent) {
+        provider = translateProvider(provider);
+
         super.requestLocationUpdates(provider, locationRequest, pendingIntent);
     }
 
     @Override
     public void requestFlush(@NonNull String provider, @NonNull LocationListener listener, int requestCode) {
+        provider = translateProvider(provider);
+
         super.requestFlush(provider, listener, requestCode);
     }
 
     @Override
     public void requestFlush(@NonNull String provider, @NonNull PendingIntent pendingIntent, int requestCode) {
+        provider = translateProvider(provider);
+
         super.requestFlush(provider, pendingIntent, requestCode);
     }
+
+
+    // Test providers do not work properly for missing underlying providers, stub them out
 
     @Override
     public void addTestProvider(@NonNull String provider, @NonNull ProviderProperties properties,
                                 @NonNull Set<String> extraAttributionTags) {
+        if (isMissingProvider(provider)) {
+            return;
+        }
+
         super.addTestProvider(provider, properties, extraAttributionTags);
     }
 
     @Override
     public void removeTestProvider(@NonNull String provider) {
+        if (isMissingProvider(provider)) {
+            return;
+        }
+
         super.removeTestProvider(provider);
     }
 
     @Override
     public void setTestProviderEnabled(@NonNull String provider, boolean enabled) {
+        if (isMissingProvider(provider)) {
+            return;
+        }
+
         super.setTestProviderEnabled(provider, enabled);
     }
 
     @Override
     public void setTestProviderLocation(@NonNull String provider, @NonNull Location location) {
+        if (isMissingProvider(provider)) {
+            return;
+        }
+
         super.setTestProviderLocation(provider, location);
     }
 }

--- a/location/java/android/location/LocationManager.java
+++ b/location/java/android/location/LocationManager.java
@@ -1801,13 +1801,6 @@ public class LocationManager {
     public boolean hasProvider(@NonNull String provider) {
         Preconditions.checkArgument(provider != null, "invalid null provider");
 
-        if (NETWORK_PROVIDER.equals(provider)) {
-            if (!getAllProviders().contains(NETWORK_PROVIDER)) {
-                android.util.Log.d("LocationManager", "returning false from hasProvider(NETWORK_PROVIDER)");
-                return false;
-            }
-        }
-
         try {
             return mService.hasProvider(provider);
         } catch (RemoteException e) {

--- a/services/core/java/com/android/server/ext/PackageManagerHooks.java
+++ b/services/core/java/com/android/server/ext/PackageManagerHooks.java
@@ -7,6 +7,7 @@ import android.app.AppBindArgs;
 import android.content.pm.GosPackageState;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManagerInternal;
+import android.location.HookedLocationManager;
 import android.os.Binder;
 import android.os.Bundle;
 import android.os.UserHandle;
@@ -117,6 +118,9 @@ public class PackageManagerHooks {
         int[] flagsArr = new int[AppBindArgs.FLAGS_ARRAY_LEN];
         flagsArr[AppBindArgs.FLAGS_IDX_SPECIAL_RUNTIME_PERMISSIONS] =
                 SpecialRuntimePermUtils.getFlags(pm, pkg, pkgState, userId);
+
+        flagsArr[AppBindArgs.FLAGS_IDX_HOOKED_LOCATION_MANAGER] =
+            HookedLocationManager.getFlags(gosPs, isUserApp);
 
         var b = new Bundle();
         b.putParcelable(AppBindArgs.KEY_GOS_PACKAGE_STATE, gosPs);

--- a/services/core/java/com/android/server/ext/PackageManagerHooks.java
+++ b/services/core/java/com/android/server/ext/PackageManagerHooks.java
@@ -109,6 +109,9 @@ public class PackageManagerHooks {
             return null;
         }
 
+        // isSystem() remains true even if isUpdatedSystemApp() is true
+        final boolean isUserApp = !pkgState.isSystem();
+
         GosPackageState gosPs = GosPackageStatePmHooks.get(pm, callingUid, packageName, userId);
 
         int[] flagsArr = new int[AppBindArgs.FLAGS_ARRAY_LEN];

--- a/services/core/java/com/android/server/location/LocationManagerService.java
+++ b/services/core/java/com/android/server/location/LocationManagerService.java
@@ -321,11 +321,6 @@ public class LocationManagerService extends ILocationManager.Stub implements
             }
         }
 
-        if (NETWORK_PROVIDER.equals(providerName)) {
-            Log.d(TAG, "replaced NETWORK with the PASSIVE provider for uid " + Binder.getCallingUid());
-            return mPassiveManager;
-        }
-
         return null;
     }
 


### PR DESCRIPTION
If there's no network location provider:
- redirect network location requests to one of available location providers
- stub out mock location management calls for network provider (TestProvider methods), since
redirecting them is infeasible

These changes apply only to third-party apps.

There's a relevant system feature (android.hardware.location.network) that is still listed as
available to improve app compatibility.
Removing it would not make this change redundant, because there are apps that try to use the network
location provider without declaring the need for this feature or checking its presence at runtime.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/2196