### PR TITLE
do not report pseudo-"network" location provider to be always disabled

### DIFF
--- a/location/java/android/location/HookedLocationManager.java
+++ b/location/java/android/location/HookedLocationManager.java
@@ -74,9 +74,7 @@ public class HookedLocationManager extends LocationManager {
 
     @Override
     public boolean isProviderEnabled(@NonNull String provider) {
-        if (isMissingProvider(provider)) {
-            return false;
-        }
+        provider = translateProvider(provider);
 
         return super.isProviderEnabled(provider);
     }


### PR DESCRIPTION
There are apps that refuse to work when isProviderEnabled("network") is false, even though "network" provider is not present in the list returned by getAllProviders().