### PR TITLE
[temporary] remove ScreenshotProxyService's dependency on CentralSurf…

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/screenshot/ScreenshotProxyService.kt
+++ b/packages/SystemUI/src/com/android/systemui/screenshot/ScreenshotProxyService.kt
@@ -34,7 +34,6 @@ import javax.inject.Inject
  */
 internal class ScreenshotProxyService @Inject constructor(
     private val mExpansionMgr: ShadeExpansionStateManager,
-    private val mCentralSurfacesOptional: Optional<CentralSurfaces>,
     @Main private val mMainDispatcher: CoroutineDispatcher,
 ) : LifecycleService() {
 
@@ -57,18 +56,7 @@ internal class ScreenshotProxyService @Inject constructor(
 
     private suspend fun executeAfterDismissing(callback: IOnDoneCallback) =
         withContext(mMainDispatcher) {
-            mCentralSurfacesOptional.ifPresentOrElse(
-                    {
-                        it.executeRunnableDismissingKeyguard(
-                                Runnable {
-                                    callback.onDone(true)
-                                }, null,
-                                true /* dismissShade */, true /* afterKeyguardGone */,
-                                true /* deferred */
-                        )
-                    },
-                    { callback.onDone(false) }
-            )
+            callback.onDone(false)
         }
 
     override fun onBind(intent: Intent): IBinder? {


### PR DESCRIPTION
…aces

Workarounds issue that causes unexpected initialisation of OverviewProxyService, when a screenshot is taken, resulting in broken recents list and launcher crashes.

Test:
1. Switch to secondary user profile (which is at rest).
2. Take screenshot and press any of the buttons in the popup.
3. Open recents list and make sure that it is working properly and the launcher isn't crashing.