### PR TITLE
gmscompat: fix incorrect deserialization of GmsFlag maps

### DIFF
--- a/core/java/com/android/internal/gmscompat/flags/GmsFlag.java
+++ b/core/java/com/android/internal/gmscompat/flags/GmsFlag.java
@@ -253,6 +253,7 @@ public class GmsFlag implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel p, int flags) {
+        p.writeString(name);
         p.writeByte(type);
         p.writeByte(permissionCheckMode);
         p.writeStringArray(permissions);
@@ -268,6 +269,7 @@ public class GmsFlag implements Parcelable {
         @Override
         public GmsFlag createFromParcel(Parcel p) {
             GmsFlag f = new GmsFlag();
+            f.name = p.readString();
             f.type = p.readByte();
             f.permissionCheckMode = p.readByte();
             f.permissions = p.readStringArray();
@@ -285,4 +287,14 @@ public class GmsFlag implements Parcelable {
             return new GmsFlag[size];
         }
     };
+
+    public static void writeMapEntry(ArrayMap<String, GmsFlag> map, int idx, Parcel dst) {
+        // map key is GmsFlag.name, do not write it twice
+        map.valueAt(idx).writeToParcel(dst, 0);
+    }
+
+    public static void readMapEntry(Parcel p, ArrayMap<String, GmsFlag> dst) {
+        GmsFlag f = GmsFlag.CREATOR.createFromParcel(p);
+        dst.append(f.name, f);
+    }
 }


### PR DESCRIPTION
In aa13847af4470457492d83814c0f76321c2c8abf , (de)serialization of GmsFlag maps was switched to use new generic methods, but

map.valueAt(i).name = map.keyAt(i);

statement from readFlagsMap() wasn't carried over. This led to incomplete deserialization of GmsFlags: all of their names were set to null, which meant that PhenotypeFlag and GservicesFlag overrides were broken.

To fix this, serialize GmsFlag.name as part of GmsFlag serialization and make ArrayMap serialization methods support generic serialization of key-value pairs, which allows to skip serializing GmsFlag.name twice (skipping it was the reason readFlagsMap() was added in the first place).