### PR TITLE
Revert "Release SCREENSHOT_WORK_PROFILE_POLICY"

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/flags/Flags.kt
+++ b/packages/SystemUI/src/com/android/systemui/flags/Flags.kt
@@ -577,7 +577,8 @@ object Flags {
     // 1300 - screenshots
     // TODO(b/254513155): Tracking Bug
     @JvmField
-    val SCREENSHOT_WORK_PROFILE_POLICY = releasedFlag(1301, "screenshot_work_profile_policy")
+    val SCREENSHOT_WORK_PROFILE_POLICY =
+        unreleasedFlag(1301, "screenshot_work_profile_policy", teamfood = true)
 
     // TODO(b/264916608): Tracking Bug
     @JvmField val SCREENSHOT_METADATA = unreleasedFlag(1302, "screenshot_metadata", teamfood = true)


### PR DESCRIPTION
This reverts commit bb146d9c12d4852bd49b5d1232ca7086d114e960.

Reason for revert: GrapheneOS/os-issue-tracker#2257