### PR TITLE
[temporary] remove ScreenshotProxyService's dependency on CentralSurf…

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/screenshot/ScreenshotProxyService.kt
+++ b/packages/SystemUI/src/com/android/systemui/screenshot/ScreenshotProxyService.kt
@@ -22,7 +22,6 @@ import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import com.android.systemui.dagger.qualifiers.Main
 import com.android.systemui.shade.ShadeExpansionStateManager
-import com.android.systemui.statusbar.phone.CentralSurfaces
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -34,7 +33,6 @@ import javax.inject.Inject
  */
 internal class ScreenshotProxyService @Inject constructor(
     private val mExpansionMgr: ShadeExpansionStateManager,
-    private val mCentralSurfacesOptional: Optional<CentralSurfaces>,
     @Main private val mMainDispatcher: CoroutineDispatcher,
 ) : LifecycleService() {
 
@@ -57,18 +55,7 @@ internal class ScreenshotProxyService @Inject constructor(
 
     private suspend fun executeAfterDismissing(callback: IOnDoneCallback) =
         withContext(mMainDispatcher) {
-            mCentralSurfacesOptional.ifPresentOrElse(
-                    {
-                        it.executeRunnableDismissingKeyguard(
-                                Runnable {
-                                    callback.onDone(true)
-                                }, null,
-                                true /* dismissShade */, true /* afterKeyguardGone */,
-                                true /* deferred */
-                        )
-                    },
-                    { callback.onDone(false) }
-            )
+            callback.onDone(false)
         }
 
     override fun onBind(intent: Intent): IBinder? {


### PR DESCRIPTION
…aces

Workarounds issue that causes unexpected initialisation of OverviewProxyService, when a screenshot is taken, resulting in broken recents list and launcher crashes.

Also, hides the action buttons (edit, share and scroll), if a screenshot is taken when device is locked, since the above change will break those action buttons. Note that the buttons are only hidden for that particular screenshot preview.

Test:
1. Switch to secondary user profile (which is at rest).
2. Take screenshot and press any of the buttons in the popup.
3. Open recents list and make sure that it is working properly and the launcher isn't crashing.