### PR TITLE
aapt2: add stringified resource configuration to Configuration.proto

### DIFF
--- a/tools/aapt2/Configuration.proto
+++ b/tools/aapt2/Configuration.proto
@@ -203,4 +203,6 @@ message Configuration {
   //
 
   string product = 25;
+
+  string stringified = 100;
 }

--- a/tools/aapt2/cmd/Convert.h
+++ b/tools/aapt2/cmd/Convert.h
@@ -43,6 +43,8 @@ class ConvertCommand : public Command {
             " '%s' output format", kOutputFormatBinary),
         &xml_flattener_options_.keep_raw_values);
     AddOptionalSwitch("-v", "Enables verbose logging", &verbose_);
+    AddOptionalSwitch("--for-adevtool", "This flag exists to prevent using adevtool with "
+            "upstream aapt2 which lacks the Configuration.proto customization.", &for_adevtool_);
   }
 
   int Action(const std::vector<std::string>& args) override;
@@ -56,6 +58,7 @@ class ConvertCommand : public Command {
   std::string output_path_;
   std::optional<std::string> output_format_;
   bool verbose_ = false;
+  bool for_adevtool_ = false;
 };
 
 int Convert(IAaptContext* context, LoadedApk* input, IArchiveWriter* output_writer,

--- a/tools/aapt2/format/proto/ProtoSerialize.cpp
+++ b/tools/aapt2/format/proto/ProtoSerialize.cpp
@@ -60,6 +60,7 @@ static pb::Visibility::Level SerializeVisibilityToPb(Visibility::Level state) {
 }
 
 void SerializeConfig(const ConfigDescription& config, pb::Configuration* out_pb_config) {
+  out_pb_config->set_stringified(config.to_string());
   out_pb_config->set_mcc(config.mcc);
   out_pb_config->set_mnc(config.mnc);
   out_pb_config->set_locale(config.GetBcp47LanguageTag());


### PR DESCRIPTION
This is needed for adevtool, to reuse large ConfigDescription.to_string() function which is used for describing resource qualifiers, e.g. "values-mcc123-sw600dp-night-en".