### PR TITLE
Revert "Revert "Remove dependency on IME subtype from TSMS""

### DIFF
--- a/services/core/java/com/android/server/textservices/TextServicesManagerService.java
+++ b/services/core/java/com/android/server/textservices/TextServicesManagerService.java
@@ -44,8 +44,6 @@ import android.service.textservice.SpellCheckerService;
 import android.text.TextUtils;
 import android.util.Slog;
 import android.util.SparseArray;
-import android.view.inputmethod.InputMethodManager;
-import android.view.inputmethod.InputMethodSubtype;
 import android.view.textservice.SpellCheckerInfo;
 import android.view.textservice.SpellCheckerSubtype;
 import android.view.textservice.SuggestionsInfo;
@@ -547,37 +545,19 @@ public class TextServicesManagerService extends ITextServicesManager.Stub {
 
         // subtypeHashCode == 0 means spell checker language settings is "auto"
 
-        Locale candidateLocale = null;
-        final InputMethodManager imm = mContext.getSystemService(InputMethodManager.class);
-        if (imm != null) {
-            final InputMethodSubtype currentInputMethodSubtype =
-                    imm.getCurrentInputMethodSubtype();
-            if (currentInputMethodSubtype != null) {
-                final String localeString = currentInputMethodSubtype.getLocale();
-                if (!TextUtils.isEmpty(localeString)) {
-                    // 1. Use keyboard locale if available in the spell checker
-                    candidateLocale = SubtypeLocaleUtils.constructLocaleFromString(localeString);
-                }
-            }
-        }
-        if (candidateLocale == null) {
-            // 2. Use System locale if available in the spell checker
-            candidateLocale = systemLocale;
-        }
-
-        if (candidateLocale == null) {
+        if (systemLocale == null) {
             return null;
         }
         SpellCheckerSubtype firstLanguageMatchingSubtype = null;
         for (int i = 0; i < sci.getSubtypeCount(); ++i) {
             final SpellCheckerSubtype scs = sci.getSubtypeAt(i);
             final Locale scsLocale = scs.getLocaleObject();
-            if (Objects.equals(scsLocale, candidateLocale)) {
+            if (Objects.equals(scsLocale, systemLocale)) {
                 // Exact match wins.
                 return scs;
             }
             if (firstLanguageMatchingSubtype == null && scsLocale != null
-                    && TextUtils.equals(candidateLocale.getLanguage(), scsLocale.getLanguage())) {
+                    && TextUtils.equals(systemLocale.getLanguage(), scsLocale.getLanguage())) {
                 // Remember as a fall back candidate
                 firstLanguageMatchingSubtype = scs;
             }


### PR DESCRIPTION
This reverts commit fdfc7783f8c083ae8a001d72b6fa6a05bbe76d67.

That commit leads to crashes in spellchecking code in secondary users.