### PR TITLE
temp: unsuspend work profile when resuming it

### DIFF
--- a/services/core/java/com/android/server/pm/UserManagerService.java
+++ b/services/core/java/com/android/server/pm/UserManagerService.java
@@ -1454,6 +1454,15 @@ public class UserManagerService extends IUserManager.Stub {
                 }
             }
         } else {
+            if (!enableQuietMode) {
+                try {
+                    getPackageManagerInternal().setPackagesSuspendedForQuietMode(userId, false);
+                    setAppOpsRestrictedForQuietMode(userId, false);
+                } catch (Exception e) {
+                    Slog.d("UserManager", "", e);
+                }
+            }
+
             // Old behavior: when quiet is enabled, profile user is stopped.
             // Old quiet mode behavior: profile user is stopped.
             // TODO(b/265683382) Remove once rollout complete.


### PR DESCRIPTION
This is needed to fix permanently suspended work profile for testers of the first Android 14-based experimental release, which suspended work profile instead of stopping it.