### PR TITLE
bugfix: Fix inconsistent check when installing from known source

### DIFF
--- a/packages/PackageInstaller/src/com/android/packageinstaller/InstallStart.java
+++ b/packages/PackageInstaller/src/com/android/packageinstaller/InstallStart.java
@@ -130,7 +130,10 @@ public class InstallStart extends Activity {
             mAbortInstall = true;
         }
 
-        checkDevicePolicyRestriction();
+        checkIfAllowedToInstall();
+        if (!isTrustedSource) {
+            checkIfAllowedToInstallUnknownSources();
+        }
 
         final String installerPackageNameFromIntent = getIntent().getStringExtra(
                 Intent.EXTRA_INSTALLER_PACKAGE_NAME);
@@ -284,7 +287,7 @@ public class InstallStart extends Activity {
         return (originatingUid == Process.ROOT_UID) || (originatingUid == installerUid);
     }
 
-    private void checkDevicePolicyRestriction() {
+    private void checkIfAllowedToInstall() {
         // Check for install apps user restriction first.
         final int installAppsRestrictionSource = mUserManager.getUserRestrictionSource(
                 UserManager.DISALLOW_INSTALL_APPS, Process.myUserHandle());
@@ -302,7 +305,9 @@ public class InstallStart extends Activity {
             startActivity(new Intent(Settings.ACTION_SHOW_ADMIN_SUPPORT_DETAILS));
             return;
         }
+    }
 
+    private void checkIfAllowedToInstallUnknownSources() {
         final int unknownSourcesRestrictionSource = mUserManager.getUserRestrictionSource(
                 UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, Process.myUserHandle());
         final int unknownSourcesGlobalRestrictionSource = mUserManager.getUserRestrictionSource(


### PR DESCRIPTION
PackageInstallerActivity checks for UserManager
restrictions for installing app before proceeding to installation process was moved to InstallStart in Android 14 as a [fix for SecurityException](https://github.com/GrapheneOS/platform_frameworks_base/commit/cc045c8cf82fd0968963d414fd0939797e5827a5). This forgot to take into account whenever
the source of installation is known or unknown, breaking installation with confirmation from known sources.