### PR TITLE
bugfix: Remove Health Connect permissions for apps not handling the required intents

### DIFF
--- a/services/core/java/com/android/server/ext/PackageManagerHooks.java
+++ b/services/core/java/com/android/server/ext/PackageManagerHooks.java
@@ -4,9 +4,11 @@ import android.Manifest;
 import android.annotation.Nullable;
 import android.annotation.UserIdInt;
 import android.app.AppBindArgs;
+import android.content.Intent;
 import android.content.pm.GosPackageState;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManagerInternal;
+import android.health.connect.HealthConnectManager;
 import android.location.HookedLocationManager;
 import android.os.Binder;
 import android.os.Build;
@@ -25,7 +27,12 @@ import com.android.server.pm.permission.SpecialRuntimePermUtils;
 import com.android.server.pm.pkg.AndroidPackage;
 import com.android.server.pm.pkg.GosPackageStatePm;
 import com.android.server.pm.pkg.PackageStateInternal;
+import com.android.server.pm.pkg.component.ParsedActivity;
+import com.android.server.pm.pkg.component.ParsedMainComponent;
+import com.android.server.pm.pkg.component.ParsedUsesPermission;
 import com.android.server.pm.pkg.parsing.ParsingPackage;
+
+import java.util.List;
 
 public class PackageManagerHooks {
 
@@ -66,6 +73,49 @@ public class PackageManagerHooks {
                 pkg.setEnabled(false);
                 return;
             default:
+                List<ParsedUsesPermission> usesPermissions = pkg.getUsesPermissions();
+                if (usesPermissions.isEmpty()) {
+                    return;
+                }
+
+                // HealthConnectManager#HEALTH_PERMISSION_PREFIX
+                String healthPermPrefix = "android.permission.health.";
+                String[] healthPermissions = usesPermissions.stream()
+                        .map(ParsedUsesPermission::getName)
+                        .filter(name -> name.startsWith(healthPermPrefix))
+                        .toArray(String[]::new);
+                if (healthPermissions.length == 0) {
+                    return;
+                }
+
+                final List<ParsedActivity> activities = pkg.getActivities();
+                if (activities.isEmpty()) {
+                    return;
+                }
+
+                final boolean shouldRemoveHealthPermission = activities.stream()
+                        .filter(ParsedMainComponent::isExported).noneMatch(
+                        a -> a.getIntents().stream().anyMatch(i -> {
+                            var filter = i.getIntentFilter();
+                            return filter.hasCategory(HealthConnectManager.CATEGORY_HEALTH_PERMISSIONS)
+                                    && filter.matchAction(Intent.ACTION_VIEW_PERMISSION_USAGE);
+                        })
+                );
+
+                if (!shouldRemoveHealthPermission) {
+                    return;
+                }
+
+                Slog.e("PackageManager", "Removing health connect permissions for " + pkgName + "."
+                        + " Apps requesting these permissions in Android 14 are required to declare an activity alias"
+                        + " with intent filters of action \"android.intent.action.VIEW_PERMISSION_USAGE\""
+                        + " and category \"android.intent.category.HEALTH_PERMISSIONS\","
+                        + " linking its rationale and privacy policy for requesting health connect permissions."
+                        + " Refer to the following documentations for details: \n"
+                        + "https://developer.android.com/health-and-fitness/guides/health-connect/develop/get-started#show-privacy-policy" + "\n"
+                        + "https://developer.android.com/reference/android/health/connect/HealthPermissions");
+
+                removeUsesPermissions(pkg, healthPermissions);
                 return;
         }
     }


### PR DESCRIPTION
This is already enforced in Health Connect app and framework part, remove the permission as well for non-complying apps in Android 14