### PR TITLE
bugfix: Remove Health Connect permissions for apps not handling the required intents

### DIFF
--- a/services/core/java/com/android/server/ext/PackageManagerHooks.java
+++ b/services/core/java/com/android/server/ext/PackageManagerHooks.java
@@ -26,6 +26,7 @@ import com.android.server.pm.pkg.AndroidPackage;
 import com.android.server.pm.pkg.GosPackageStatePm;
 import com.android.server.pm.pkg.PackageStateInternal;
 import com.android.server.pm.pkg.parsing.ParsingPackage;
+import com.android.server.pm.pkg.parsing.ParsingPackageUtils;
 
 public class PackageManagerHooks {
 
@@ -51,7 +52,7 @@ public class PackageManagerHooks {
     }
 
     // Called when package parsing is completed
-    public static void amendParsedPackage(ParsingPackage pkg) {
+    public static void amendParsedPackage(ParsingPackage pkg, @ParsingPackageUtils.ParseFlags int flags) {
         String pkgName = pkg.getPackageName();
 
         switch (pkgName) {

--- a/services/core/java/com/android/server/pm/pkg/parsing/ParsingPackageUtils.java
+++ b/services/core/java/com/android/server/pm/pkg/parsing/ParsingPackageUtils.java
@@ -2191,7 +2191,7 @@ public class ParsingPackageUtils {
             pkg.addActivity(a.getResult());
         }
 
-        PackageManagerHooks.amendParsedPackage(pkg);
+        PackageManagerHooks.amendParsedPackage(pkg, flags);
         GmsSysServerHooks.amendParsedPackage(pkg);
 
         if (hasActivityOrder) {


### PR DESCRIPTION
Resolves https://github.com/GrapheneOS/os-issue-tracker/issues/2583

This change removes Health permissions for app missing the activity-alias required linking its privacy policy for requesting the permission, otherwise, it cannot be granted by AOSP checks for handling the intents documented at https://developer.android.com/health-and-fitness/guides/health-connect/develop/get-started#show-privacy-policy, https://developer.android.com/reference/android/health/connect/HealthPermissions.

Refer to the following code on its enforcement at AOSP, which also impacts Stock OS as of its initial QPR1 beta release, and stable release at October: at [the Health Connect app side](https://cs.android.com/android/_/android/platform/packages/modules/HealthFitness/+/3085250fb50abd7a7d4fb0944ce34fdf88f8581c:apk/src/com/android/healthconnect/controller/permissions/shared/SettingsActivity.kt;drc=3085250fb50abd7a7d4fb0944ce34fdf88f8581c;l=87), and [its framework](https://cs.android.com/android/platform/superproject/main/+/main:packages/modules/HealthFitness/service/java/com/android/server/healthconnect/permission/HealthConnectPermissionHelper.java;drc=bc731ba07f76947347bf0c5744863008e5667044;l=310)