### PR TITLE
Revert "don't skip showing first app crash dialog"

### DIFF
--- a/services/core/java/com/android/server/am/AppErrors.java
+++ b/services/core/java/com/android/server/am/AppErrors.java
@@ -1041,7 +1041,9 @@ class AppErrors {
                     crashShowErrorTime = mProcessCrashShowDialogTimes.get(proc.processName,
                             proc.uid);
                 }
-                final boolean showFirstCrash = true;
+                final boolean showFirstCrash = Settings.Global.getInt(
+                        mContext.getContentResolver(),
+                        Settings.Global.SHOW_FIRST_CRASH_DIALOG, 0) != 0;
                 final boolean showFirstCrashDevOption = Settings.Secure.getIntForUser(
                         mContext.getContentResolver(),
                         Settings.Secure.SHOW_FIRST_CRASH_DIALOG_DEV_OPTION,


### PR DESCRIPTION
This reverts commit 2e895adfaddd6c5b7f21ab9237521a600f5b40a5.

This setting applies, counter-intuitively, to background as well as foreground crashes.
Moreover, it uncovers a large number of non-actionable third-party app bugs.