### PR TITLE
gmscompat: replace cross-user intent broadcasts with user-local ones

### DIFF
--- a/core/java/android/app/ContextImpl.java
+++ b/core/java/android/app/ContextImpl.java
@@ -100,9 +100,9 @@ import android.window.WindowContext;
 import android.window.WindowTokenClient;
 
 import com.android.internal.annotations.GuardedBy;
-import com.android.internal.gmscompat.GmsInfo;
 import com.android.internal.gmscompat.sysservice.GmcPackageManager;
 import com.android.internal.gmscompat.GmsHooks;
+import com.android.internal.gmscompat.sysservice.GmcUserManager;
 import com.android.internal.util.Preconditions;
 
 import dalvik.system.BlockGuard;
@@ -1462,6 +1462,10 @@ class ContextImpl extends Context {
 
     @Override
     public void sendBroadcastAsUser(Intent intent, UserHandle user) {
+        if (GmsCompat.isEnabled()) {
+            user = GmcUserManager.translateUserHandle(user);
+        }
+
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         try {
             intent.prepareToLeaveProcess(this);
@@ -1485,6 +1489,7 @@ class ContextImpl extends Context {
             Bundle options) {
         if (GmsCompat.isEnabled()) {
             options = GmsHooks.filterBroadcastOptions(intent, options);
+            user = GmcUserManager.translateUserHandle(user);
         }
 
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
@@ -1505,6 +1510,10 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcastAsUser(Intent intent, UserHandle user,
             String receiverPermission, int appOp) {
+        if (GmsCompat.isEnabled()) {
+            user = GmcUserManager.translateUserHandle(user);
+        }
+
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         String[] receiverPermissions = receiverPermission == null ? null
                 : new String[] {receiverPermission};
@@ -1542,6 +1551,7 @@ class ContextImpl extends Context {
             Handler scheduler, int initialCode, String initialData, Bundle initialExtras) {
         if (GmsCompat.isEnabled()) {
             options = GmsHooks.filterBroadcastOptions(intent, options);
+            user = GmcUserManager.translateUserHandle(user);
         }
 
         IIntentReceiver rd = null;

--- a/core/java/com/android/internal/gmscompat/sysservice/GmcUserManager.java
+++ b/core/java/com/android/internal/gmscompat/sysservice/GmcUserManager.java
@@ -43,9 +43,18 @@ public class GmcUserManager extends UserManager {
     }
 
     private static void checkUserId(int userId) {
-        if (userId != getUserId()) {
+        if (userId != getUserId() && userId != UserHandle.USER_CURRENT) {
             throw new IllegalStateException("unexpected userId " + userId);
         }
+    }
+
+    public static UserHandle translateUserHandle(UserHandle h) {
+        if (UserHandle.ALL.equals(h)) {
+            return UserHandle.of(getUserId());
+        }
+
+        checkUserId(h.getIdentifier());
+        return h;
     }
 
     private static int getUserSerialNumber() {


### PR DESCRIPTION
Cross-user broadcasts require a privileged permission.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/2649