### PR TITLE
WMShellUnitTests: remove reference to mockito-kotlin2 module

### DIFF
--- a/libs/WindowManager/Shell/tests/unittest/Android.bp
+++ b/libs/WindowManager/Shell/tests/unittest/Android.bp
@@ -43,7 +43,6 @@ android_test {
         "frameworks-base-testutils",
         "kotlinx-coroutines-android",
         "kotlinx-coroutines-core",
-        "mockito-kotlin2",
         "mockito-target-extended-minus-junit4",
         "truth-prebuilt",
         "testables",


### PR DESCRIPTION
It's defined in platform/external/mockito-kotlin, which is not tagged and is missing from the manifest.