### PR TITLE
Revert "Convert BubbleDataRepositoryTest to use mockito-kotlin"

### DIFF
--- a/libs/WindowManager/Shell/tests/unittest/Android.bp
+++ b/libs/WindowManager/Shell/tests/unittest/Android.bp
@@ -43,7 +43,6 @@ android_test {
         "frameworks-base-testutils",
         "kotlinx-coroutines-android",
         "kotlinx-coroutines-core",
-        "mockito-kotlin2",
         "mockito-target-extended-minus-junit4",
         "truth-prebuilt",
         "testables",

--- a/libs/WindowManager/Shell/tests/unittest/src/com/android/wm/shell/bubbles/BubbleDataRepositoryTest.kt
+++ b/libs/WindowManager/Shell/tests/unittest/src/com/android/wm/shell/bubbles/BubbleDataRepositoryTest.kt
@@ -29,11 +29,11 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.spy
-import org.mockito.kotlin.verify
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
 
 class BubbleDataRepositoryTest : ShellTestCase() {
 
@@ -124,7 +124,7 @@ class BubbleDataRepositoryTest : ShellTestCase() {
 
     private val testHandler = Handler(Looper.getMainLooper())
     private val mainExecutor = HandlerExecutor(testHandler)
-    private val launcherApps = mock<LauncherApps>()
+    private val launcherApps = mock(LauncherApps::class.java)
 
     private val persistedBubbles = SparseArray<List<BubbleEntity>>()
 
@@ -158,7 +158,8 @@ class BubbleDataRepositoryTest : ShellTestCase() {
         assertThat(persistedBubbles).isEqualTo(validEntitiesByUser)
 
         // No invalid users, so no persist to disk happened
-        verify(dataRepository, never()).persistToDisk(any())
+        verify(dataRepository, never()).persistToDisk(
+            any(SparseArray<List<BubbleEntity>>()::class.java))
     }
 
     @Test
@@ -198,4 +199,6 @@ class BubbleDataRepositoryTest : ShellTestCase() {
         // Verify that persist to disk happened with the new valid entities list.
         verify(dataRepository).persistToDisk(validEntitiesByUser)
     }
+
+    fun <T> any(type: Class<T>): T = Mockito.any<T>(type)
 }


### PR DESCRIPTION
This reverts commit 625a23ff22f0a9327b9a24341dfa0b8fbaf61a1b.

mockito-kotlin2 is defined in platform/external/mockito-kotlin, which is not tagged and is missing from the manifest.