### PR TITLE
disable support for pre-approving PackageInstaller sessions; bugfixes

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -6590,7 +6590,7 @@
          the underlying display device changes. -->
     <bool name="config_persistBrightnessNitsForDefaultDisplay">false</bool>
     <!-- Whether to request the approval before commit sessions. -->
-    <bool name="config_isPreApprovalRequestAvailable">true</bool>
+    <bool name="config_isPreApprovalRequestAvailable">false</bool>
 
     <!-- Whether the AOSP support for app cloning building blocks is to be enabled for the
          device. -->

--- a/services/core/java/com/android/server/biometrics/BiometricService.java
+++ b/services/core/java/com/android/server/biometrics/BiometricService.java
@@ -385,10 +385,13 @@ public class BiometricService extends SystemService {
         }
 
         void notifyEnabledOnKeyguardCallbacks(int userId) {
-            List<EnabledOnKeyguardCallback> callbacks = mCallbacks;
-            for (int i = 0; i < callbacks.size(); i++) {
-                callbacks.get(i).notify(
-                        mBiometricEnabledOnKeyguard.getOrDefault(userId, DEFAULT_KEYGUARD_ENABLED),
+            EnabledOnKeyguardCallback[] callbacks = mCallbacks.toArray(new EnabledOnKeyguardCallback[0]);
+            for (var cb : callbacks) {
+                if (cb == null) {
+                    Slog.d(TAG, "null callback in notifyEnabledOnKeyguardCallbacks", new Throwable());
+                    continue;
+                }
+                cb.notify(mBiometricEnabledOnKeyguard.getOrDefault(userId, DEFAULT_KEYGUARD_ENABLED),
                         userId);
             }
         }

--- a/services/core/java/com/android/server/ext/BluetoothAutoOff.java
+++ b/services/core/java/com/android/server/ext/BluetoothAutoOff.java
@@ -13,6 +13,8 @@ import android.os.Build;
 import android.util.Slog;
 
 class BluetoothAutoOff extends DelayedConditionalAction {
+    private static final String TAG = BluetoothAutoOff.class.getSimpleName();
+
     private final BluetoothManager manager;
     @Nullable
     private final BluetoothAdapter adapter;
@@ -44,9 +46,7 @@ class BluetoothAutoOff extends DelayedConditionalAction {
         sse.context.registerReceiver(new BroadcastReceiver() {
             @Override
             public void onReceive(Context broadcastContext, Intent intent) {
-                if (Build.isDebuggable()) {
-                    Slog.d("BtAutoOff", "" + intent + ", extras " + intent.getExtras().deepCopy());
-                }
+                Slog.d(TAG, "" + intent + ", extras " + intent.getExtras().deepCopy());
                 update();
             }
         }, f, null, handler);

--- a/services/core/java/com/android/server/ext/MissingSpecialRuntimePermissionNotification.java
+++ b/services/core/java/com/android/server/ext/MissingSpecialRuntimePermissionNotification.java
@@ -76,11 +76,16 @@ public class MissingSpecialRuntimePermissionNotification {
         var nb = new Notification.Builder(ctx, SystemNotificationChannels.MISSING_PERMISSION);
         nb.setSmallIcon(R.drawable.stat_sys_warning);
 
-        CharSequence appLabel;
+        CharSequence appLabel = null;
         {
             ApplicationInfo appInfo = LocalServices.getService(PackageManagerInternal.class)
                     .getApplicationInfo(packageName, 0, Process.SYSTEM_UID, user.getIdentifier());
-            appLabel = appInfo.loadLabel(ctx.getPackageManager());
+            if (appInfo != null) {
+                appLabel = appInfo.loadLabel(ctx.getPackageManager());
+            }
+            if (appLabel == null) {
+                appLabel = packageName;
+            }
         }
         nb.setContentTitle(ctx.getString(R.string.missing_sensors_permission_title, appLabel));
 


### PR DESCRIPTION
See https://developer.android.com/reference/android/content/pm/PackageInstaller.Session#requestUserPreapproval(android.content.pm.PackageInstaller.PreapprovalDetails,%20android.content.IntentSender)

Closes 
https://github.com/GrapheneOS/os-issue-tracker/issues/2942
https://github.com/GrapheneOS/os-issue-tracker/issues/2947
