### PR TITLE
bugfix: Check first if PackageInstaller is the calling app to uninstall an app silently

### DIFF
--- a/services/core/java/com/android/server/pm/DeletePackageHelper.java
+++ b/services/core/java/com/android/server/pm/DeletePackageHelper.java
@@ -859,6 +859,12 @@ final class DeletePackageHelper {
             return true;
         }
         final int callingUserId = UserHandle.getUserId(callingUid);
+        // Allow package uninstaller to silently uninstall.
+        if (mPm.mRequiredUninstallerPackage != null && callingUid == snapshot
+                .getPackageUid(mPm.mRequiredUninstallerPackage, 0, callingUserId)) {
+            return true;
+        }
+
         // If the caller installed the pkgName, then allow it to silently uninstall.
         if (callingUid == snapshot.getPackageUid(
                 snapshot.getInstallerPackageName(pkgName, userId), 0, callingUserId)) {
@@ -870,12 +876,6 @@ final class DeletePackageHelper {
             if (callingUid == snapshot.getPackageUid(verifierPackageName, 0, callingUserId)) {
                 return true;
             }
-        }
-
-        // Allow package uninstaller to silently uninstall.
-        if (mPm.mRequiredUninstallerPackage != null && callingUid == snapshot
-                .getPackageUid(mPm.mRequiredUninstallerPackage, 0, callingUserId)) {
-            return true;
         }
 
         // Allow storage manager to silently uninstall.


### PR DESCRIPTION


Recent changes in package visibility mechanism introduces a stricter filtering mechanism where it takes into account if a package is installed in the current user. In primary users, an option is provided to uninstall an app on all users, and this doesn't work as intended for one of the conditions checked uses this stricter filtering mechanism, namely if the caller installed the package it's uninstalliung.

Hence, as PackageInstaller also possesses `DELETE_PACKAGES` permission, have it take precedence on the series of check whether the calling app can uninstall a package silently, to allow "Uninstall on all users" options in Settings work as intended.