### PR TITLE
add setting for USB port security state

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -234,6 +234,7 @@ java_library {
         "android.hardware.usb-V1.0-java-constants",
         "android.hardware.usb-V1.1-java-constants",
         "android.hardware.usb-V1.2-java-constants",
+        "android.hardware.usb.ext-V1-java",
         "android.hardware.usb.gadget-V1-java",
         "android.hardware.usb.gadget-V1.0-java",
         "android.hardware.usb.gadget-V1.1-java",

--- a/core/java/android/ext/settings/UsbPortSecurity.java
+++ b/core/java/android/ext/settings/UsbPortSecurity.java
@@ -1,0 +1,16 @@
+package android.ext.settings;
+
+/** @hide */
+public class UsbPortSecurity {
+    public static final int MODE_DISABLED = 0;
+    public static final int MODE_CHARGING_ONLY = 1;
+    // doesn't apply to connections that were made before locking
+    public static final int MODE_CHARGING_ONLY_WHEN_LOCKED = 2;
+    // doesn't apply to connections that were made before locking or first unlock
+    public static final int MODE_CHARGING_ONLY_WHEN_LOCKED_AFU = 3;
+    public static final int MODE_ENABLED = 4;
+
+    // keep in sync with USB HAL implementations that check this sysprop during init
+    public static final IntSysProperty MODE_SETTING = new IntSysProperty(
+            "persist.security.usb_mode", MODE_ENABLED);
+}

--- a/core/java/android/hardware/usb/IUsbManager.aidl
+++ b/core/java/android/hardware/usb/IUsbManager.aidl
@@ -196,4 +196,7 @@ interface IUsbManager
             "@android.annotation.RequiresPermission(android.Manifest.permission.MANAGE_USB)")
     void unregisterForDisplayPortEvents(IDisplayPortAltModeInfoListener listener);
 
+    @JavaPassthrough(annotation=
+            "@android.annotation.RequiresPermission(android.Manifest.permission.MANAGE_USB)")
+    void setPortSecurityState(String portId, int state);
 }

--- a/core/java/android/hardware/usb/UsbManager.java
+++ b/core/java/android/hardware/usb/UsbManager.java
@@ -1599,6 +1599,16 @@ public class UsbManager {
         }
     }
 
+    /** @hide */
+    public void setPortSecurityState(@NonNull UsbPort port,
+                              @android.hardware.usb.ext.PortSecurityState int state) {
+        try {
+            mService.setPortSecurityState(port.getId(), state);
+        } catch (RemoteException e) {
+            throw e.rethrowFromSystemServer();
+        }
+    }
+
     /**
      * Should only be called by {@link UsbPort#enableUsbDataWhileDocked}.
      * <p>

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -6613,4 +6613,7 @@
     <bool name="config_GoogleCamera_needs_seinfo_for_access_to_accelerators">false</bool>
 
     <string name="config_gnssPsdsType"></string>
+
+    <bool name="config_usbPortSecuritySupported">false</bool>
+    <java-symbol type="bool" name="config_usbPortSecuritySupported" />
 </resources>

--- a/services/core/java/com/android/server/policy/keyguard/KeyguardStateMonitor.java
+++ b/services/core/java/com/android/server/policy/keyguard/KeyguardStateMonitor.java
@@ -19,6 +19,7 @@ package com.android.server.policy.keyguard;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.ext.settings.ExtSettings;
+import android.os.Binder;
 import android.os.RemoteException;
 import android.os.SystemProperties;
 import android.util.Slog;
@@ -35,6 +36,8 @@ import java.io.PrintWriter;
  */
 public class KeyguardStateMonitor extends IKeyguardStateCallback.Stub {
     private static final String TAG = "KeyguardStateMonitor";
+
+    private final Context mContext;
 
     // These cache the current state of Keyguard to improve performance and avoid deadlock. After
     // Keyguard changes its state, it always triggers a layout in window manager. Because
@@ -53,6 +56,7 @@ public class KeyguardStateMonitor extends IKeyguardStateCallback.Stub {
     private final StateCallback mCallback;
 
     public KeyguardStateMonitor(Context context, IKeyguardService service, StateCallback callback) {
+        mContext = context;
         mLockPatternUtils = new LockPatternUtils(context);
         mCurrentUserId = ActivityManager.getCurrentUser();
         mCallback = callback;
@@ -96,6 +100,13 @@ public class KeyguardStateMonitor extends IKeyguardStateCallback.Stub {
             SystemProperties.set(ExtSettings.DENY_NEW_USB_TRANSIENT_PROP, showing ?
                     ExtSettings.DENY_NEW_USB_TRANSIENT_ENABLE :
                     ExtSettings.DENY_NEW_USB_TRANSIENT_DISABLE);
+        }
+
+        final long token = Binder.clearCallingIdentity();
+        try {
+            UsbPortSecurityHooks.onKeyguardShowingStateChanged(mContext, showing, userId);
+        } finally {
+            Binder.restoreCallingIdentity(token);
         }
 
         if (showing) {

--- a/services/core/java/com/android/server/policy/keyguard/UsbPortSecurityHooks.java
+++ b/services/core/java/com/android/server/policy/keyguard/UsbPortSecurityHooks.java
@@ -1,0 +1,49 @@
+package com.android.server.policy.keyguard;
+
+import android.content.Context;
+import android.ext.settings.UsbPortSecurity;
+import android.hardware.usb.UsbManager;
+import android.hardware.usb.UsbPort;
+import android.os.UserHandle;
+import android.util.Slog;
+
+import com.android.internal.R;
+
+public class UsbPortSecurityHooks {
+    private static final String TAG = UsbPortSecurityHooks.class.getSimpleName();
+
+    private static volatile boolean keyguardShownAtLeastOnce;
+
+    public static void onKeyguardShowingStateChanged(Context ctx, boolean showing, int userId) {
+        if (!ctx.getResources().getBoolean(R.bool.config_usbPortSecuritySupported)) {
+            return;
+        }
+
+        int setting = UsbPortSecurity.MODE_SETTING.get();
+
+        Slog.d(TAG, "onKeyguardShowingStateChanged, showing " + showing + ", userId " + userId
+                + ", modeSetting " + setting);
+
+        if (setting == UsbPortSecurity.MODE_CHARGING_ONLY_WHEN_LOCKED
+              || (keyguardShownAtLeastOnce && setting == UsbPortSecurity.MODE_CHARGING_ONLY_WHEN_LOCKED_AFU))
+        {
+            int mode = showing ?
+                    android.hardware.usb.ext.PortSecurityState.CHARGING_ONLY :
+                    android.hardware.usb.ext.PortSecurityState.ENABLED;
+
+            UsbManager um = ctx.getSystemService(UsbManager.class);
+            for (UsbPort p : um.getPorts()) {
+                try {
+                    um.setPortSecurityState(p, mode);
+                } catch (Exception e) {
+                    // don't crash the system_server
+                    Slog.e(TAG, "", e);
+                }
+            }
+        }
+
+        if (userId == UserHandle.USER_SYSTEM && showing) {
+            keyguardShownAtLeastOnce = true;
+        }
+    }
+}

--- a/services/usb/Android.bp
+++ b/services/usb/Android.bp
@@ -34,5 +34,6 @@ java_library_static {
         "android.hardware.usb-V1.2-java",
         "android.hardware.usb-V1.3-java",
         "android.hardware.usb-V2-java",
+        "android.hardware.usb.ext-V1-java",
     ],
 }

--- a/services/usb/java/com/android/server/usb/UsbPortManager.java
+++ b/services/usb/java/com/android/server/usb/UsbPortManager.java
@@ -437,6 +437,11 @@ public class UsbPortManager implements IBinder.DeathRecipient {
         }
     }
 
+    public void setPortSecurityState(@NonNull String portId,
+                                     @android.hardware.usb.ext.PortSecurityState int state) {
+        mUsbPortHal.setPortSecurityState(portId, state);
+    }
+
     /**
      * Enable/disable the USB data signaling
      *

--- a/services/usb/java/com/android/server/usb/UsbService.java
+++ b/services/usb/java/com/android/server/usb/UsbService.java
@@ -911,6 +911,12 @@ public class UsbService extends IUsbManager.Stub {
         }
     }
 
+    public void setPortSecurityState(@NonNull String portId,
+                                     @android.hardware.usb.ext.PortSecurityState int state) {
+        mContext.enforceCallingOrSelfPermission(android.Manifest.permission.MANAGE_USB, null);
+        mPortManager.setPortSecurityState(portId, state);
+    }
+
     @Override
     public void setUsbDeviceConnectionHandler(ComponentName usbDeviceConnectionHandler) {
         mContext.enforceCallingOrSelfPermission(android.Manifest.permission.MANAGE_USB, null);

--- a/services/usb/java/com/android/server/usb/hal/port/UsbPortAidl.java
+++ b/services/usb/java/com/android/server/usb/hal/port/UsbPortAidl.java
@@ -39,6 +39,8 @@ import android.hardware.usb.DisplayPortAltModeInfo;
 import android.hardware.usb.AltModeData;
 import android.hardware.usb.AltModeData.DisplayPortAltModeData;
 import android.hardware.usb.DisplayPortAltModePinAssignment;
+import android.hardware.usb.ext.IUsbExt;
+import android.hardware.usb.ext.PortSecurityState;
 import android.os.Build;
 import android.os.ServiceManager;
 import android.os.IBinder;
@@ -454,6 +456,30 @@ public final class UsbPortAidl implements UsbPortHal {
                         + portName + " opID:" + operationID, e);
             }
         }
+    }
+
+    @Override
+    public void setPortSecurityState(String portName, @android.hardware.usb.ext.PortSecurityState int state) {
+        IBinder ext;
+        try {
+            ext = mBinder.getExtension();
+        } catch (RemoteException e) {
+            Slog.e(TAG, "", e);
+            throw new UnsupportedOperationException(e);
+        }
+
+        if (ext == null) {
+            Slog.d(TAG, "setPortSecurityState: no IUsbExt");
+            throw new UnsupportedOperationException();
+        }
+
+        IUsbExt i = IUsbExt.Stub.asInterface(ext);
+        try {
+            i.setPortSecurityState(portName, state);
+        } catch (RemoteException e) {
+            Slog.e(TAG, "", e);
+        }
+        Slog.d(TAG, "setPortSecurityState: " + state);
     }
 
     private static class HALCallback extends IUsbCallback.Stub {

--- a/services/usb/java/com/android/server/usb/hal/port/UsbPortHal.java
+++ b/services/usb/java/com/android/server/usb/hal/port/UsbPortHal.java
@@ -18,6 +18,7 @@ package com.android.server.usb.hal.port;
 import android.annotation.IntDef;
 import android.hardware.usb.IUsbOperationInternal;
 import android.hardware.usb.UsbManager.UsbHalVersion;
+import android.hardware.usb.ext.PortSecurityState;
 import android.os.RemoteException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -205,4 +206,8 @@ public interface UsbPortHal {
      */
     public void resetUsbPort(String portName, long transactionId,
             IUsbOperationInternal callback);
+
+    default void setPortSecurityState(String portName, @android.hardware.usb.ext.PortSecurityState int state) {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
Part of a changelist:
https://github.com/GrapheneOS/platform_hardware_interfaces/pull/1

https://github.com/GrapheneOS/kernel_common-5.10/pull/25
https://github.com/GrapheneOS/kernel_gs/pull/22
https://github.com/GrapheneOS/device_google_gs101/pull/39
https://github.com/GrapheneOS/device_google_gs201/pull/15

https://github.com/GrapheneOS/kernel_common-5.15/pull/7
https://github.com/GrapheneOS/kernel_google-modules_soc_gs/pull/1
https://github.com/GrapheneOS/device_google_zuma/pull/7

https://github.com/GrapheneOS/platform_system_core/pull/18

https://github.com/GrapheneOS/platform_system_sepolicy/pull/51

https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/225

