### PR TITLE
fixup! SystemUI: Require unlocking to use sensitive QS tiles

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/SecureQSTile.kt
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/SecureQSTile.kt
@@ -29,7 +29,7 @@ import com.android.systemui.qs.tileimpl.QSTileImpl
 import com.android.systemui.qs.QsEventLogger;
 import com.android.systemui.statusbar.policy.KeyguardStateController
 
-internal abstract class SecureQSTile<TState : QSTile.State> protected constructor(
+abstract class SecureQSTile<TState : QSTile.State> protected constructor(
     host: QSHost, uiEventLogger: QsEventLogger, backgroundLooper: Looper, mainHandler: Handler,
     falsingManager: FalsingManager, metricsLogger: MetricsLogger, statusBarStateController: StatusBarStateController,
     activityStarter: ActivityStarter, qsLogger: QSLogger,


### PR DESCRIPTION
InternetTileNewImpl is used instead of InternetTile. Keep changes to both for now in case InternetTileNewImpl usage gets reverted.