### PR TITLE
SystemUI: respect setting for use of DeviceControlsTile from lockscreen

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/DeviceControlsTile.kt
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/DeviceControlsTile.kt
@@ -100,6 +100,8 @@ class DeviceControlsTile @Inject constructor(
         }
     }
 
+    override fun isAllowedWhenLocked(action: Action) = true
+
     override fun handleClick(view: View?) {
         if (state.state == Tile.STATE_UNAVAILABLE) {
             return


### PR DESCRIPTION
Handling of Settings toggle is in handleClick(), which is not reached when locked unless isAllowedWhenLocked returns true.