### PR TITLE
gmscompat: ignore VendorConfigProvider in CarrierSettings app

### DIFF
--- a/core/java/com/android/internal/pm/parsing/pkg/PackageImpl.java
+++ b/core/java/com/android/internal/pm/parsing/pkg/PackageImpl.java
@@ -626,6 +626,10 @@ public class PackageImpl implements ParsedPackage, AndroidPackageInternal,
 
     @Override
     public PackageImpl addProvider(ParsedProvider parsedProvider) {
+        if (getPackageParsingHooks().shouldSkipProvider(parsedProvider)) {
+            return this;
+        }
+
         this.providers = CollectionUtils.add(this.providers, parsedProvider);
         addMimeGroupsFromComponent(parsedProvider);
         return this;

--- a/core/java/com/android/internal/pm/pkg/parsing/PackageParsingHooks.java
+++ b/core/java/com/android/internal/pm/pkg/parsing/PackageParsingHooks.java
@@ -4,6 +4,7 @@ import android.annotation.Nullable;
 import android.content.pm.PackageManager;
 
 import com.android.internal.pm.pkg.component.ParsedPermission;
+import com.android.internal.pm.pkg.component.ParsedProvider;
 import com.android.internal.pm.pkg.component.ParsedService;
 import com.android.internal.pm.pkg.component.ParsedServiceImpl;
 import com.android.internal.pm.pkg.component.ParsedUsesPermission;
@@ -20,6 +21,10 @@ public class PackageParsingHooks {
     }
 
     public boolean shouldSkipUsesPermission(ParsedUsesPermission p) {
+        return false;
+    }
+
+    public boolean shouldSkipProvider(ParsedProvider p) {
         return false;
     }
 

--- a/core/java/com/android/internal/pm/pkg/parsing/ParsingPackageUtils.java
+++ b/core/java/com/android/internal/pm/pkg/parsing/ParsingPackageUtils.java
@@ -751,7 +751,6 @@ public class ParsingPackageUtils {
                     "coreApp", false);
             final ParsingPackage pkg = mCallback.startParsingPackage(
                     pkgName, apkPath, codePath, manifestArray, isCoreApp);
-            pkg.initPackageParsingHooks();
             final ParseResult<ParsingPackage> result =
                     parseBaseApkTags(input, pkg, manifestArray, res, parser, flags,
                             shouldSkipComponents);

--- a/services/core/java/com/android/server/pm/ext/GCarrierSettingsHooks.java
+++ b/services/core/java/com/android/server/pm/ext/GCarrierSettingsHooks.java
@@ -3,6 +3,7 @@ package com.android.server.pm.ext;
 import android.Manifest;
 
 import com.android.internal.gmscompat.gcarriersettings.TestCarrierConfigService;
+import com.android.internal.pm.pkg.component.ParsedProvider;
 import com.android.internal.pm.pkg.component.ParsedService;
 import com.android.internal.pm.pkg.component.ParsedUsesPermission;
 import com.android.internal.pm.pkg.parsing.ParsingPackage;
@@ -26,6 +27,11 @@ class GCarrierSettingsHooks extends PackageHooks {
         public List<ParsedService> addServices(ParsingPackage pkg) {
             ParsedService s = createService(pkg, TestCarrierConfigService.class.getName());
             return Collections.singletonList(s);
+        }
+
+        @Override
+        public boolean shouldSkipProvider(ParsedProvider p) {
+            return "com.google.android.carrier.vendorprovider".equals(p.getAuthority());
         }
     }
 

--- a/services/core/java/com/android/server/pm/parsing/PackageParser2.java
+++ b/services/core/java/com/android/server/pm/parsing/PackageParser2.java
@@ -241,8 +241,10 @@ public class PackageParser2 implements AutoCloseable {
         public final ParsingPackage startParsingPackage(@NonNull String packageName,
                 @NonNull String baseCodePath, @NonNull String codePath,
                 @NonNull TypedArray manifestArray, boolean isCoreApp) {
-            return PackageImpl.forParsing(packageName, baseCodePath, codePath, manifestArray,
+            var res = PackageImpl.forParsing(packageName, baseCodePath, codePath, manifestArray,
                     isCoreApp, Callback.this);
+            res.initPackageParsingHooks();
+            return res;
         }
 
         /**


### PR DESCRIPTION
VendorConfigProvider is already defined in CarrierConfig2 app, which blocked installation of
Google's CarrierSettings app that is used by CarrierConfig2 for testing purposes.