### PR TITLE
disable most of PackageManagerService code for handling instant apps

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -367,7 +367,7 @@ public class PackageManagerService implements PackageSender, TestUtilityService 
 
     static final String SHELL_PACKAGE_NAME = "com.android.shell";
 
-    static final boolean HIDE_EPHEMERAL_APIS = false;
+    static final boolean HIDE_EPHEMERAL_APIS = true;
 
     static final String PRECOMPILE_LAYOUTS = "pm.precompile_layouts";
 


### PR DESCRIPTION
HIDE_EPHEMERAL_APIS flag reduces PackageManagerService attack surface by disabling most of the code for handling instant apps.