### PR TITLE
Do not use filter calling uid parameter originally intended for instant apps.

### DIFF
--- a/services/core/java/com/android/server/wm/ActivityStarter.java
+++ b/services/core/java/com/android/server/wm/ActivityStarter.java
@@ -495,7 +495,6 @@ class ActivityStarter {
             avoidMoveToFront = request.avoidMoveToFront;
             allowPendingRemoteAnimationRegistryLookup
                     = request.allowPendingRemoteAnimationRegistryLookup;
-            filterCallingUid = request.filterCallingUid;
             originatingPendingIntent = request.originatingPendingIntent;
             forcedBalByPiSender = request.forcedBalByPiSender;
             errorCallbackToken = request.errorCallbackToken;
@@ -1458,9 +1457,7 @@ class ActivityStarter {
      */
     static int computeResolveFilterUid(int customCallingUid, int actualCallingUid,
             int filterCallingUid) {
-        return filterCallingUid != UserHandle.USER_NULL
-                ? filterCallingUid
-                : (customCallingUid >= 0 ? customCallingUid : actualCallingUid);
+        return customCallingUid >= 0 ? customCallingUid : actualCallingUid;
     }
 
     /**
@@ -3159,11 +3156,6 @@ class ActivityStarter {
 
     ActivityStarter setIgnoreTargetSecurity(boolean ignoreTargetSecurity) {
         mRequest.ignoreTargetSecurity = ignoreTargetSecurity;
-        return this;
-    }
-
-    ActivityStarter setFilterCallingUid(int filterCallingUid) {
-        mRequest.filterCallingUid = filterCallingUid;
         return this;
     }
 

--- a/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
+++ b/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
@@ -1681,7 +1681,6 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
                     .setActivityOptions(createSafeActivityOptionsWithBalAllowed(bOptions))
                     .setUserId(userId)
                     .setIgnoreTargetSecurity(ignoreTargetSecurity)
-                    .setFilterCallingUid(isResolver ? 0 /* system */ : targetUid)
                     // The target may well be in the background, which would normally prevent it
                     // from starting an activity. Here we definitely want the start to succeed.
                     .setBackgroundStartPrivileges(BackgroundStartPrivileges.ALLOW_BAL)


### PR DESCRIPTION
Instant apps and its API are unsupported on GrapheneOS, and there's no need to set the root uid as filterCallingUid when resolving an activity not started by instant apps. Activity starts are not blocked by package visibility feature.

See https://cs.android.com/android/_/android/platform/frameworks/base/+/31426b265f33a40d6241bd110f63499051cae2b0 for the change introducing filterCallingUid