### PR TITLE
increase default max password length to 128

### DIFF
--- a/core/java/android/app/admin/DevicePolicyManager.java
+++ b/core/java/android/app/admin/DevicePolicyManager.java
@@ -3634,7 +3634,7 @@ public class DevicePolicyManager {
      * Maximum supported password length. Kind-of arbitrary.
      * @hide
      */
-    public static final int MAX_PASSWORD_LENGTH = 64;
+    public static final int MAX_PASSWORD_LENGTH = 128;
 
     /**
      * Service Action: Service implemented by a device owner or profile owner supervision app to


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/3540