### PR TITLE
Disallow the camera shortcut toggle from the lockscreen

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/camera/CameraGestureHelper.kt
+++ b/packages/SystemUI/src/com/android/systemui/camera/CameraGestureHelper.kt
@@ -24,6 +24,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
+import android.ext.settings.ExtSettings
 import android.os.RemoteException
 import android.util.Log
 import android.view.WindowManager
@@ -90,6 +91,9 @@ class CameraGestureHelper @Inject constructor(
         val wouldLaunchResolverActivity = activityIntentHelper.wouldLaunchResolverActivity(
             intent, selectedUserInteractor.getSelectedUserId()
         )
+        if (!ExtSettings.ALLOW_KEYGUARD_CAMERA.get(context) && !keyguardStateController.isUnlocked()) {
+            return
+        }
         if (CameraIntents.isSecureCameraIntent(intent) && !wouldLaunchResolverActivity) {
             uiExecutor.execute {
                 // Normally an activity will set its requested rotation animation on its window.


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/2508

Demo: https://youtube.com/shorts/pi8nH4sXaRA?feature=share