### PR TITLE
change default UsbPortSecurity mode to CHARGING_ONLY_WHEN_LOCKED

### DIFF
--- a/core/java/android/ext/settings/UsbPortSecurity.java
+++ b/core/java/android/ext/settings/UsbPortSecurity.java
@@ -12,5 +12,5 @@ public class UsbPortSecurity {
 
     // keep in sync with USB HAL implementations that check this sysprop during init
     public static final IntSysProperty MODE_SETTING = new IntSysProperty(
-            "persist.security.usb_mode", MODE_CHARGING_ONLY_WHEN_LOCKED_AFU);
+            "persist.security.usb_mode", MODE_CHARGING_ONLY_WHEN_LOCKED);
 }


### PR DESCRIPTION
Part of a changelist:
https://github.com/GrapheneOS/device_google_gs101/pull/47
https://github.com/GrapheneOS/device_google_gs201/pull/20
https://github.com/GrapheneOS/device_google_zuma/pull/13