### PR TITLE
Revert "Remove SystemUIDialog subclass from InternetDialog"

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/InternetTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/InternetTile.java
@@ -52,7 +52,7 @@ import com.android.systemui.qs.QSHost;
 import com.android.systemui.qs.QsEventLogger;
 import com.android.systemui.qs.logging.QSLogger;
 import com.android.systemui.qs.tileimpl.QSTileImpl;
-import com.android.systemui.qs.tiles.dialog.InternetDialogManager;
+import com.android.systemui.qs.tiles.dialog.InternetDialogFactory;
 import com.android.systemui.statusbar.connectivity.AccessPointController;
 import com.android.systemui.statusbar.connectivity.IconState;
 import com.android.systemui.statusbar.connectivity.MobileDataIndicators;
@@ -83,7 +83,7 @@ public class InternetTile extends QSTileImpl<QSTile.BooleanState> {
     private int mLastTileState = LAST_STATE_UNKNOWN;
 
     protected final InternetSignalCallback mSignalCallback = new InternetSignalCallback();
-    private final InternetDialogManager mInternetDialogManager;
+    private final InternetDialogFactory mInternetDialogFactory;
     final Handler mHandler;
 
     @Inject
@@ -99,11 +99,11 @@ public class InternetTile extends QSTileImpl<QSTile.BooleanState> {
             QSLogger qsLogger,
             NetworkController networkController,
             AccessPointController accessPointController,
-            InternetDialogManager internetDialogManager
+            InternetDialogFactory internetDialogFactory
     ) {
         super(host, uiEventLogger, backgroundLooper, mainHandler, falsingManager, metricsLogger,
                 statusBarStateController, activityStarter, qsLogger);
-        mInternetDialogManager = internetDialogManager;
+        mInternetDialogFactory = internetDialogFactory;
         mHandler = mainHandler;
         mController = networkController;
         mAccessPointController = accessPointController;
@@ -125,7 +125,7 @@ public class InternetTile extends QSTileImpl<QSTile.BooleanState> {
 
     @Override
     protected void handleClick(@Nullable View view) {
-        mHandler.post(() -> mInternetDialogManager.create(true,
+        mHandler.post(() -> mInternetDialogFactory.create(true,
                 mAccessPointController.canConfigMobileData(),
                 mAccessPointController.canConfigWifi(), view));
     }

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/InternetTileNewImpl.kt
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/InternetTileNewImpl.kt
@@ -33,7 +33,7 @@ import com.android.systemui.qs.QSHost
 import com.android.systemui.qs.QsEventLogger
 import com.android.systemui.qs.logging.QSLogger
 import com.android.systemui.qs.tileimpl.QSTileImpl
-import com.android.systemui.qs.tiles.dialog.InternetDialogManager
+import com.android.systemui.qs.tiles.dialog.InternetDialogFactory
 import com.android.systemui.res.R
 import com.android.systemui.statusbar.connectivity.AccessPointController
 import com.android.systemui.statusbar.pipeline.shared.ui.binder.InternetTileBinder
@@ -44,18 +44,18 @@ import javax.inject.Inject
 class InternetTileNewImpl
 @Inject
 constructor(
-        host: QSHost,
-        uiEventLogger: QsEventLogger,
-        @Background backgroundLooper: Looper,
-        @Main private val mainHandler: Handler,
-        falsingManager: FalsingManager,
-        metricsLogger: MetricsLogger,
-        statusBarStateController: StatusBarStateController,
-        activityStarter: ActivityStarter,
-        qsLogger: QSLogger,
-        viewModel: InternetTileViewModel,
-        private val internetDialogManager: InternetDialogManager,
-        private val accessPointController: AccessPointController,
+    host: QSHost,
+    uiEventLogger: QsEventLogger,
+    @Background backgroundLooper: Looper,
+    @Main private val mainHandler: Handler,
+    falsingManager: FalsingManager,
+    metricsLogger: MetricsLogger,
+    statusBarStateController: StatusBarStateController,
+    activityStarter: ActivityStarter,
+    qsLogger: QSLogger,
+    viewModel: InternetTileViewModel,
+    private val internetDialogFactory: InternetDialogFactory,
+    private val accessPointController: AccessPointController,
 ) :
     QSTileImpl<QSTile.BooleanState>(
         host,
@@ -86,7 +86,7 @@ constructor(
 
     override fun handleClick(view: View?) {
         mainHandler.post {
-            internetDialogManager.create(
+            internetDialogFactory.create(
                 aboveStatusBar = true,
                 accessPointController.canConfigMobileData(),
                 accessPointController.canConfigWifi(),

--- a/packages/SystemUI/src/com/android/systemui/statusbar/connectivity/NetworkControllerImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/connectivity/NetworkControllerImpl.java
@@ -61,6 +61,7 @@ import com.android.settingslib.mobile.MobileStatusTracker.SubscriptionDefaults;
 import com.android.settingslib.mobile.TelephonyIcons;
 import com.android.settingslib.net.DataUsageController;
 import com.android.systemui.Dumpable;
+import com.android.systemui.res.R;
 import com.android.systemui.broadcast.BroadcastDispatcher;
 import com.android.systemui.dagger.SysUISingleton;
 import com.android.systemui.dagger.qualifiers.Background;
@@ -71,8 +72,7 @@ import com.android.systemui.dump.DumpManager;
 import com.android.systemui.log.LogBuffer;
 import com.android.systemui.log.core.LogLevel;
 import com.android.systemui.log.dagger.StatusBarNetworkControllerLog;
-import com.android.systemui.qs.tiles.dialog.InternetDialogManager;
-import com.android.systemui.res.R;
+import com.android.systemui.qs.tiles.dialog.InternetDialogFactory;
 import com.android.systemui.settings.UserTracker;
 import com.android.systemui.statusbar.pipeline.StatusBarPipelineFlags;
 import com.android.systemui.statusbar.policy.ConfigurationController;
@@ -82,6 +82,8 @@ import com.android.systemui.statusbar.policy.DeviceProvisionedController;
 import com.android.systemui.statusbar.policy.DeviceProvisionedController.DeviceProvisionedListener;
 import com.android.systemui.telephony.TelephonyListenerManager;
 import com.android.systemui.util.CarrierConfigTracker;
+
+import dalvik.annotation.optimization.NeverCompile;
 
 import java.io.PrintWriter;
 import java.text.SimpleDateFormat;
@@ -97,7 +99,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import dalvik.annotation.optimization.NeverCompile;
 import kotlin.Unit;
 
 /** Platform implementation of the network controller. **/
@@ -200,7 +201,7 @@ public class NetworkControllerImpl extends BroadcastReceiver
     private boolean mUserSetup;
     private boolean mSimDetected;
     private boolean mForceCellularValidated;
-    private InternetDialogManager mInternetDialogManager;
+    private InternetDialogFactory mInternetDialogFactory;
     private Handler mMainHandler;
 
     private ConfigurationController.ConfigurationListener mConfigurationListener =
@@ -244,7 +245,7 @@ public class NetworkControllerImpl extends BroadcastReceiver
             WifiStatusTrackerFactory trackerFactory,
             MobileSignalControllerFactory mobileFactory,
             @Main Handler handler,
-            InternetDialogManager internetDialogManager,
+            InternetDialogFactory internetDialogFactory,
             DumpManager dumpManager,
             @StatusBarNetworkControllerLog LogBuffer logBuffer) {
         this(context, connectivityManager,
@@ -271,7 +272,7 @@ public class NetworkControllerImpl extends BroadcastReceiver
                 dumpManager,
                 logBuffer);
         mReceiverHandler.post(mRegisterListeners);
-        mInternetDialogManager = internetDialogManager;
+        mInternetDialogFactory = internetDialogFactory;
     }
 
     @VisibleForTesting
@@ -828,7 +829,7 @@ public class NetworkControllerImpl extends BroadcastReceiver
                 mReceiverHandler.post(this::handleConfigurationChanged);
                 break;
             case Settings.Panel.ACTION_INTERNET_CONNECTIVITY:
-                mMainHandler.post(() -> mInternetDialogManager.create(true,
+                mMainHandler.post(() -> mInternetDialogFactory.create(true,
                         mAccessPoints.canConfigMobileData(), mAccessPoints.canConfigWifi(),
                         null /* view */));
                 break;

--- a/packages/SystemUI/tests/src/com/android/systemui/qs/tiles/InternetTileNewImplTest.kt
+++ b/packages/SystemUI/tests/src/com/android/systemui/qs/tiles/InternetTileNewImplTest.kt
@@ -30,7 +30,7 @@ import com.android.systemui.plugins.statusbar.StatusBarStateController
 import com.android.systemui.qs.QSHost
 import com.android.systemui.qs.QsEventLogger
 import com.android.systemui.qs.logging.QSLogger
-import com.android.systemui.qs.tiles.dialog.InternetDialogManager
+import com.android.systemui.qs.tiles.dialog.InternetDialogFactory
 import com.android.systemui.statusbar.connectivity.AccessPointController
 import com.android.systemui.statusbar.pipeline.airplane.data.repository.FakeAirplaneModeRepository
 import com.android.systemui.statusbar.pipeline.ethernet.domain.EthernetInteractor
@@ -83,7 +83,7 @@ class InternetTileNewImplTest : SysuiTestCase() {
     @Mock private lateinit var sbStateController: StatusBarStateController
     @Mock private lateinit var activityStarter: ActivityStarter
     @Mock private lateinit var logger: QSLogger
-    @Mock private lateinit var dialogManager: InternetDialogManager
+    @Mock private lateinit var dialogFactory: InternetDialogFactory
     @Mock private lateinit var accessPointController: AccessPointController
 
     @Before
@@ -118,7 +118,7 @@ class InternetTileNewImplTest : SysuiTestCase() {
                 activityStarter,
                 logger,
                 viewModel,
-                dialogManager,
+                dialogFactory,
                 accessPointController
             )
 

--- a/packages/SystemUI/tests/src/com/android/systemui/qs/tiles/InternetTileTest.java
+++ b/packages/SystemUI/tests/src/com/android/systemui/qs/tiles/InternetTileTest.java
@@ -17,6 +17,7 @@
 package com.android.systemui.qs.tiles;
 
 import static com.google.common.truth.Truth.assertThat;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -37,7 +38,7 @@ import com.android.systemui.qs.QSHost;
 import com.android.systemui.qs.QsEventLogger;
 import com.android.systemui.qs.logging.QSLogger;
 import com.android.systemui.qs.tileimpl.QSTileImpl;
-import com.android.systemui.qs.tiles.dialog.InternetDialogManager;
+import com.android.systemui.qs.tiles.dialog.InternetDialogFactory;
 import com.android.systemui.statusbar.connectivity.AccessPointController;
 import com.android.systemui.statusbar.connectivity.IconState;
 import com.android.systemui.statusbar.connectivity.NetworkController;
@@ -62,7 +63,7 @@ public class InternetTileTest extends SysuiTestCase {
     @Mock
     private AccessPointController mAccessPointController;
     @Mock
-    private InternetDialogManager mInternetDialogManager;
+    private InternetDialogFactory mInternetDialogFactory;
     @Mock
     private QsEventLogger mUiEventLogger;
 
@@ -88,7 +89,7 @@ public class InternetTileTest extends SysuiTestCase {
             mock(QSLogger.class),
             mNetworkController,
             mAccessPointController,
-                mInternetDialogManager
+            mInternetDialogFactory
         );
 
         mTile.initialize();

--- a/packages/SystemUI/tests/src/com/android/systemui/qs/tiles/dialog/InternetDialogControllerTest.java
+++ b/packages/SystemUI/tests/src/com/android/systemui/qs/tiles/dialog/InternetDialogControllerTest.java
@@ -5,6 +5,7 @@ import static android.provider.Settings.Global.AIRPLANE_MODE_ON;
 import static android.telephony.SignalStrength.NUM_SIGNAL_STRENGTH_BINS;
 import static android.telephony.SignalStrength.SIGNAL_STRENGTH_GREAT;
 import static android.telephony.SignalStrength.SIGNAL_STRENGTH_POOR;
+
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.mockitoSession;
 import static com.android.settingslib.wifi.WifiUtils.getHotspotIconResource;
 import static com.android.systemui.qs.tiles.dialog.InternetDialogController.TOAST_PARAMS_HORIZONTAL_WEIGHT;
@@ -12,7 +13,9 @@ import static com.android.systemui.qs.tiles.dialog.InternetDialogController.TOAS
 import static com.android.wifitrackerlib.WifiEntry.WIFI_LEVEL_MAX;
 import static com.android.wifitrackerlib.WifiEntry.WIFI_LEVEL_MIN;
 import static com.android.wifitrackerlib.WifiEntry.WIFI_LEVEL_UNREACHABLE;
+
 import static com.google.common.truth.Truth.assertThat;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -98,7 +101,7 @@ import java.util.Map;
 @SmallTest
 @RunWith(AndroidTestingRunner.class)
 @TestableLooper.RunWithLooper(setAsMainLooper = true)
-public class InternetDialogDelegateControllerTest extends SysuiTestCase {
+public class InternetDialogControllerTest extends SysuiTestCase {
 
     private static final int SUB_ID = 1;
     private static final int SUB_ID2 = 2;


### PR DESCRIPTION
This reverts commit 7e259ee6c576164371babaef85db9a2f9be6f4ce.

Reverted change regressed the Internet quick settings tile in secondary users.