### PR TITLE
extend USB port security API to pogo pins; integrate deny_new_usb into USB port security API

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -7005,4 +7005,6 @@
 
     <bool name="config_usbPortSecuritySupported">false</bool>
     <java-symbol type="bool" name="config_usbPortSecuritySupported" />
+    <bool name="config_usb_port_security_applies_to_pogo_pins">false</bool>
+    <java-symbol type="bool" name="config_usb_port_security_applies_to_pogo_pins" />
 </resources>


### PR DESCRIPTION
Part of a changelist:
https://github.com/GrapheneOS/kernel_common-5.15/pull/8
https://github.com/GrapheneOS/kernel_common-5.10/pull/26
https://github.com/GrapheneOS/kernel_gs/pull/24

https://github.com/GrapheneOS/kernel_manifest-gs/pull/4
https://github.com/GrapheneOS/kernel_devices_google_tangorpro/pull/1
https://github.com/GrapheneOS/script/pull/59

https://github.com/GrapheneOS/device_google_tangorpro/pull/9

https://github.com/GrapheneOS/platform_system_core/pull/20
https://github.com/GrapheneOS/platform_system_sepolicy/pull/57
https://github.com/GrapheneOS/platform_hardware_interfaces/pull/3

https://github.com/GrapheneOS/device_google_gs201/pull/23
https://github.com/GrapheneOS/device_google_gs101/pull/49
https://github.com/GrapheneOS/device_google_zuma/pull/15

https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/252

