### PR TITLE
bugfix: Use cast checking first before casting to PackageExt

### DIFF
--- a/services/core/java/com/android/server/pm/ext/PackageExt.java
+++ b/services/core/java/com/android/server/pm/ext/PackageExt.java
@@ -20,7 +20,7 @@ public class PackageExt implements PackageExtIface {
 
     public static PackageExt get(AndroidPackage pkg) {
         PackageExtIface i = pkg.ext();
-        if (i != null) {
+        if (i instanceof PackageExt) {
             return (PackageExt) i;
         }
         return DEFAULT;


### PR DESCRIPTION
There's another implementation for PackageExtIFace, namely PackageExtDefault and class casting exception is encountered in cases where this was the non-null instance acquired.