### PR TITLE
add status callback to USB port security state API and use it in USB port security setting implementation

### DIFF
--- a/core/java/android/hardware/usb/IUsbManager.aidl
+++ b/core/java/android/hardware/usb/IUsbManager.aidl
@@ -217,5 +217,5 @@ interface IUsbManager
 
     @JavaPassthrough(annotation=
             "@android.annotation.RequiresPermission(android.Manifest.permission.MANAGE_USB)")
-    void setPortSecurityState(String portId, int state);
+    void setPortSecurityState(String portId, int state, in android.os.ResultReceiver callback);
 }

--- a/core/java/android/hardware/usb/UsbManager.java
+++ b/core/java/android/hardware/usb/UsbManager.java
@@ -1621,9 +1621,10 @@ public class UsbManager {
 
     /** @hide */
     public void setPortSecurityState(@NonNull UsbPort port,
-                              @android.hardware.usb.ext.PortSecurityState int state) {
+            @android.hardware.usb.ext.PortSecurityState int state,
+            @NonNull android.os.ResultReceiver statusCallback) {
         try {
-            mService.setPortSecurityState(port.getId(), state);
+            mService.setPortSecurityState(port.getId(), state, statusCallback);
         } catch (RemoteException e) {
             throw e.rethrowFromSystemServer();
         }

--- a/services/core/java/com/android/server/policy/keyguard/UsbPortSecurityHooks.java
+++ b/services/core/java/com/android/server/policy/keyguard/UsbPortSecurityHooks.java
@@ -9,7 +9,9 @@ import android.ext.settings.UsbPortSecurity;
 import android.hardware.usb.UsbManager;
 import android.hardware.usb.UsbPort;
 import android.hardware.usb.UsbPortStatus;
+import android.os.Bundle;
 import android.os.Handler;
+import android.os.ResultReceiver;
 import android.os.UserHandle;
 import android.util.Slog;
 
@@ -125,13 +127,19 @@ public class UsbPortSecurityHooks {
             return;
         }
 
-        for (UsbPort p : um.getPorts()) {
-            try {
-                um.setPortSecurityState(p, state);
-            } catch (Exception e) {
-                // don't crash the system_server
-                Slog.e(TAG, "", e);
-            }
+        for (UsbPort port : um.getPorts()) {
+            var resultReceiver = new ResultReceiver(null) {
+                @Override
+                protected void onReceiveResult(int resultCode, Bundle resultData) {
+                    if (resultCode != android.hardware.usb.ext.IUsbExt.NO_ERROR) {
+                        throw new IllegalStateException("setPortSecurityState failed, resultCode: " + resultCode + ", port: " + port);
+                    }
+
+                    Slog.d(TAG, "setPortSecurityState succeeded for port : " + port.getId());
+                }
+            };
+
+            um.setPortSecurityState(port, state, resultReceiver);
         }
     }
 }

--- a/services/usb/java/com/android/server/usb/UsbPortManager.java
+++ b/services/usb/java/com/android/server/usb/UsbPortManager.java
@@ -448,8 +448,9 @@ public class UsbPortManager implements IBinder.DeathRecipient {
     }
 
     public void setPortSecurityState(@NonNull String portId,
-                                     @android.hardware.usb.ext.PortSecurityState int state) {
-        mUsbPortHal.setPortSecurityState(portId, state);
+                                     @android.hardware.usb.ext.PortSecurityState int state,
+                                     android.os.ResultReceiver callback) {
+        mUsbPortHal.setPortSecurityState(portId, state, callback);
     }
 
     /**

--- a/services/usb/java/com/android/server/usb/UsbService.java
+++ b/services/usb/java/com/android/server/usb/UsbService.java
@@ -998,10 +998,13 @@ public class UsbService extends IUsbManager.Stub {
         }
     }
 
+    @Override
     public void setPortSecurityState(@NonNull String portId,
-                                     @android.hardware.usb.ext.PortSecurityState int state) {
+                                     @android.hardware.usb.ext.PortSecurityState int state,
+                                     android.os.ResultReceiver callback) {
         mContext.enforceCallingOrSelfPermission(android.Manifest.permission.MANAGE_USB, null);
-        mPortManager.setPortSecurityState(portId, state);
+        Objects.requireNonNull(callback, "callback");
+        mPortManager.setPortSecurityState(portId, state, callback);
     }
 
     @android.annotation.EnforcePermission(android.Manifest.permission.MANAGE_USB)

--- a/services/usb/java/com/android/server/usb/hal/port/UsbPortHal.java
+++ b/services/usb/java/com/android/server/usb/hal/port/UsbPortHal.java
@@ -207,7 +207,9 @@ public interface UsbPortHal {
     public void resetUsbPort(String portName, long transactionId,
             IUsbOperationInternal callback);
 
-    default void setPortSecurityState(String portName, @android.hardware.usb.ext.PortSecurityState int state) {
+    default void setPortSecurityState(String portName,
+                                      @android.hardware.usb.ext.PortSecurityState int state,
+                                      android.os.ResultReceiver callback) {
         throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
Part of a changelist:
https://github.com/GrapheneOS/platform_hardware_interfaces/pull/4

https://github.com/GrapheneOS/device_google_gs201/pull/24
https://github.com/GrapheneOS/device_google_gs101/pull/50
https://github.com/GrapheneOS/device_google_zuma/pull/16

https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/253

