### PR TITLE
gmscompat: don't let Play Store abort pending package installation

### DIFF
--- a/core/java/android/content/pm/IPackageInstallerSession.aidl
+++ b/core/java/android/content/pm/IPackageInstallerSession.aidl
@@ -61,6 +61,7 @@ interface IPackageInstallerSession {
     int[] getChildSessionIds();
     void addChildSessionId(in int sessionId);
     void removeChildSessionId(in int sessionId);
+    int getId();
     int getParentSessionId();
 
     boolean isStaged();

--- a/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
+++ b/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
@@ -149,8 +149,6 @@ public class PackageInstallerActivity extends Activity {
 
     // Would the mOk button be enabled if this activity would be resumed
     private boolean mEnableOk = false;
-    private boolean mPermissionResultWasSet;
-    private boolean mAllowNextOnPause;
 
     private AlertDialog mDialog;
 
@@ -392,7 +390,7 @@ public class PackageInstallerActivity extends Activity {
         if (icicle != null) {
             mAllowUnknownSources = icicle.getBoolean(ALLOW_UNKNOWN_SOURCES_KEY);
         }
-        getWindow().setCloseOnTouchOutside(false);
+        setFinishOnTouchOutside(true);
 
         mPm = getPackageManager();
         mAppOpsManager = (AppOpsManager) getSystemService(Context.APP_OPS_SERVICE);
@@ -502,24 +500,6 @@ public class PackageInstallerActivity extends Activity {
             // Don't allow the install button to be clicked as there might be overlays
             mOk.setEnabled(false);
         }
-        // sometimes this activity becomes hidden after onPause(),
-        // and the user is unable to bring it back
-        if (!mPermissionResultWasSet && mSessionId != -1) {
-            if (mAllowNextOnPause) {
-                mAllowNextOnPause = false;
-            } else {
-                if (!isFinishing()) {
-                    finish();
-                }
-            }
-        }
-    }
-
-    // handles startActivity() calls too
-    @Override
-    public void startActivityForResult(Intent intent, int requestCode, Bundle options) {
-        mAllowNextOnPause = true;
-        super.startActivityForResult(intent, requestCode, options);
     }
 
     @Override
@@ -534,9 +514,6 @@ public class PackageInstallerActivity extends Activity {
         super.onDestroy();
         while (!mActiveUnknownSourcesListeners.isEmpty()) {
             unregister(mActiveUnknownSourcesListeners.get(0));
-        }
-        if (!mPermissionResultWasSet) {
-            mInstaller.setPermissionsResult(mSessionId, false);
         }
     }
 
@@ -593,7 +570,6 @@ public class PackageInstallerActivity extends Activity {
             } else {
                 mInstaller.setPermissionsResult(mSessionId, false);
             }
-            mPermissionResultWasSet = true;
         }
         super.finish();
     }

--- a/services/core/java/com/android/server/pm/PackageInstallerSession.java
+++ b/services/core/java/com/android/server/pm/PackageInstallerSession.java
@@ -5010,6 +5010,11 @@ public class PackageInstallerSession extends IPackageInstallerSession.Stub {
     }
 
     @Override
+    public int getId() {
+        return sessionId;
+    }
+
+    @Override
     public int getParentSessionId() {
         synchronized (mLock) {
             return mParentSessionId;


### PR DESCRIPTION
Play Store doesn't expect committed PackageInstaller sessions to be waiting for confirmation from
the user and destroys them if they haven't completed in ~10 minutes.