### PR TITLE
bugfix: fix equality check for Computer#filterAppAccess(int, int)

### DIFF
--- a/services/core/java/com/android/server/pm/ComputerEngine.java
+++ b/services/core/java/com/android/server/pm/ComputerEngine.java
@@ -2962,7 +2962,7 @@ public class ComputerEngine implements Computer {
             }
             final int clientAppUid = Process.getAppUidForSdkSandboxUid(uid);
             // Client app of this sdk sandbox process should be able to see it.
-            if (clientAppUid == uid) {
+            if (callingUid == clientAppUid) {
                 return false;
             }
             // Nobody else should be able to see the sdk sandbox process.


### PR DESCRIPTION
This provides the intended documented behavior where sdk sandbox process can see its client app process. Upstream code has a logic bug where the variable `uid`, when its value is within the sdk sandbox process, is compared to the variable `clientAppUid`, where its value is the client app of the sdk sandbox process. From the method `Process.getAppUidForSdkSandboxUid`, `clientAppUid` would never be equal to `uid`, making this codepath behave in contrary to the above comment "Client app of this sdk sandbox process should be able to see it".