### PR TITLE
fixup! integrate Google's eUICC LPA package (EuiccGoogle)

### DIFF
--- a/services/core/java/com/android/server/pm/ext/EuiccGoogleHooks.java
+++ b/services/core/java/com/android/server/pm/ext/EuiccGoogleHooks.java
@@ -34,15 +34,16 @@ class EuiccGoogleHooks extends PackageHooks {
 
     @Override
     public boolean shouldBlockPackageVisibility(int userId, PackageStateInternal otherPkg) {
-        AndroidPackage otherApk = otherPkg.getAndroidPackage();
-        if (otherApk != null && PackageExt.get(otherApk).getPackageId() == PackageId.TYCHO) {
-            return false;
+        // EuiccGoogle is a privileged app, block it from interacting with unprivileged
+        // parts of sandboxed Google Play
+        switch (otherPkg.getPackageName()) {
+            case PackageId.GSF_NAME:
+            case PackageId.GMS_CORE_NAME:
+            case PackageId.PLAY_STORE_NAME:
+                return true;
         }
 
-        // Block EuiccGoogle from interacting with GmsCore, which is used for feature flags, logging,
-        // perf data reporting etc.
-        //
-        // Block visibility for the rest of non-system packages to reduce the attack surface.
-        return !otherPkg.isSystem();
+        // Some third-party carrier apps need to interact with EuiccGoogle for eSIM activation
+        return false;
     }
 }


### PR DESCRIPTION
Don't block visibility between EuiccGoogle and third-party apps, since some third-party carrier apps need to interact with EuiccGoogle for eSIM activation.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/3794