### PR TITLE
require owner credential to check whether duress password is present 

### DIFF
--- a/core/java/com/android/internal/widget/ILockSettings.aidl
+++ b/core/java/com/android/internal/widget/ILockSettings.aidl
@@ -110,5 +110,5 @@ interface ILockSettings {
     boolean isWeakEscrowTokenValid(long handle, in byte[] token, int userId);
     void unlockUserKeyIfUnsecured(int userId);
     void setDuressCredentials(in LockscreenCredential ownerCredential, in LockscreenCredential duressPin, in LockscreenCredential duressPassword);
-    boolean hasDuressCredentials();
+    boolean hasDuressCredentials(in LockscreenCredential ownerCredential);
 }

--- a/core/java/com/android/internal/widget/LockPatternUtils.java
+++ b/core/java/com/android/internal/widget/LockPatternUtils.java
@@ -2049,9 +2049,9 @@ public class LockPatternUtils {
         }
     }
 
-    public boolean hasDuressCredentials() {
+    public boolean hasDuressCredentials(@NonNull LockscreenCredential ownerCredential) {
         try {
-            return getLockSettings().hasDuressCredentials();
+            return getLockSettings().hasDuressCredentials(ownerCredential);
         } catch (RemoteException e) {
             throw e.rethrowFromSystemServer();
         }

--- a/services/core/java/com/android/server/ext/TombstoneHandler.java
+++ b/services/core/java/com/android/server/ext/TombstoneHandler.java
@@ -369,6 +369,14 @@ public class TombstoneHandler {
                     , "android::hardware::bluetooth::hci::HciFlowControl::~HciFlowControl()"
                     , "android::hardware::bluetooth::hci::shim::Deinitialize()"
                     , "android::hardware::bluetooth::aidl::bcmbtlinux::BluetoothHci::signal_handler(int)"
+            ) || checkBacktraceFunctionNames(backtrace, 0
+                    , "abort"
+                    , "fatal_error"
+                    , "deallocate_small"
+                    , "android::hardware::bluetooth::hci::shim::DeinitializeCallback()"
+                    , "android::hardware::bluetooth::hci::HciFlowControl::~HciFlowControl()"
+                    , "android::hardware::bluetooth::hci::shim::Deinitialize()"
+                    , "android::hardware::bluetooth::aidl::bcmbtlinux::BluetoothHci::signal_handler(int)"
             );
         }
 

--- a/services/core/java/com/android/server/locksettings/LockSettingsService.java
+++ b/services/core/java/com/android/server/locksettings/LockSettingsService.java
@@ -3792,9 +3792,9 @@ public class LockSettingsService extends ILockSettings.Stub {
     }
 
     @Override
-    public boolean hasDuressCredentials() {
+    public boolean hasDuressCredentials(LockscreenCredential ownerCredential) {
         checkPasswordHavePermission();
-        return duressPasswordHelper.hasDuressCredentials();
+        return duressPasswordHelper.hasDuressCredentials(ownerCredential);
     }
 
     Context getContext() {


### PR DESCRIPTION
Previously, ACCESS_KEYGUARD_SECURE_STORAGE permission was enough to check that.

Presence of duress password is intended to be unknown unless the owner credential is provided. This
was enforced in the UI layer (Settings app) already, but could be bypassed through UI bugs, such
as the recently patched predictive back gesture bug:
https://github.com/GrapheneOS/platform_packages_apps_Settings/commit/e6ac6fa0f33f9b69cbcb4464fa46d93b548b0f2a

Depends on https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/269