### PR TITLE
PackageInstaller: fix NPE due to a race condition in PackageUtil

### DIFF
--- a/packages/PackageInstaller/src/com/android/packageinstaller/PackageUtil.java
+++ b/packages/PackageInstaller/src/com/android/packageinstaller/PackageUtil.java
@@ -76,7 +76,8 @@ public class PackageUtil {
         String filePath = sourceFile.getAbsolutePath();
         if (filePath.endsWith(SPLIT_BASE_APK_END_WITH)) {
             File dir = sourceFile.getParentFile();
-            if (dir.listFiles().length > 1) {
+            File[] dirContents = dir.listFiles();
+            if (dirContents != null && dirContents.length > 1) {
                 // split apks, use file directory to get archive info
                 filePath = dir.getPath();
             }


### PR DESCRIPTION
Directory can be removed by the time listFiles() is called, which makes it return null. Null can also be returned due to an I/O error.

Resolves https://github.com/GrapheneOS/os-issue-tracker/issues/3854